### PR TITLE
Fix Hamamatsu VUV tile dimensions

### DIFF
--- a/source/geometries/TileHamamatsuVUV.cc
+++ b/source/geometries/TileHamamatsuVUV.cc
@@ -38,9 +38,9 @@ TileHamamatsuVUV::TileHamamatsuVUV() : TileGeometryBase(),
                                        sipm_pitch_(7.5 * mm),
                                        n_rows_(4),
                                        n_columns_(4),
-                                       lxe_thick_(0.35 * mm),
+                                       lxe_thick_(0.6 * mm),
                                        quartz_rindex_(1.6), //Given by Hamamatsu
-                                       quartz_thick_(0.5 * mm)
+                                       quartz_thick_(0.6 * mm)
 
 {
   sipm_ = new SiPMHamamatsuVUV();

--- a/source/geometries/TileHamamatsuVUV.cc
+++ b/source/geometries/TileHamamatsuVUV.cc
@@ -34,7 +34,7 @@ using namespace CLHEP;
 TileHamamatsuVUV::TileHamamatsuVUV() : TileGeometryBase(),
                                        tile_x_(30.9 * mm),
                                        tile_y_(30.7 * mm),
-                                       tile_z_(2.3 * mm), // From Simón's 3d model. Hamamatsu file says 2.5. To be checked in the lab.
+                                       tile_z_(2.3 * mm),
                                        sipm_pitch_(7.5 * mm),
                                        n_rows_(4),
                                        n_columns_(4),

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -200,7 +200,7 @@ def test_create_petalo_output_file_pet_box_all_tiles(config_tmpdir, output_tmpdi
 
 /nexus/persistency/outputFile {output_tmpdir}/{base_name}
 
-/nexus/random_seed 23102020
+/nexus/random_seed 23102022
 """
 
      config_path = os.path.join(config_tmpdir, base_name+'.config.mac')


### PR DESCRIPTION
This PR fixes the dimensions of the quartz and LXe in `TileHamamatsuVUV.cc` according to the specification sheet from Hamamatsu.

z_quartz + z_LXe  = 1.2 mm (Hamamatsu specification sheet)
z_quartz (measured by Simón) = 0.6 mm --> z_LXe = 0.6 mm