### PR TITLE
Add empty material properties to all materials, to avoid crashes

### DIFF
--- a/source/geometries/FullRingInfinity.cc
+++ b/source/geometries/FullRingInfinity.cc
@@ -256,8 +256,9 @@ void FullRingInfinity::BuildCryostat()
       new G4Tubs("VACUUM_VESSEL", vessel_int_radius, vessel_ext_radius,
                  vessel_width/2., 0, twopi);
     G4Material* steel = materials::Steel();
-        G4LogicalVolume* vessel_logic =
-          new G4LogicalVolume(vessel_solid, steel, "VACUUM_VESSEL");
+    steel->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    G4LogicalVolume* vessel_logic =
+      new G4LogicalVolume(vessel_solid, steel, "VACUUM_VESSEL");
     new G4PVPlacement(0, G4ThreeVector(0., 0., 0.), vessel_logic,
 		      "VACUUM_VESSEL", lab_logic_, false, 0, true);
 
@@ -266,6 +267,7 @@ void FullRingInfinity::BuildCryostat()
       new G4Tubs("VACUUM", vacuum_int_radius, vacuum_ext_radius,
                  lxe_container_width/2., 0, twopi);
     G4Material* vacuum = G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
+    vacuum->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
     G4LogicalVolume* vacuum_logic =
           new G4LogicalVolume(vacuum_solid, vacuum, "VACUUM");
     new G4PVPlacement(0, G4ThreeVector(0., 0., 0.), vacuum_logic,
@@ -276,6 +278,7 @@ void FullRingInfinity::BuildCryostat()
                  lxe_container_width/2., 0, twopi);
 
     G4Material* aluminum = G4NistManager::Instance()->FindOrBuildMaterial("G4_Al");
+    aluminum->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
     G4LogicalVolume* lxe_container_logic =
       new G4LogicalVolume(lxe_container_solid, aluminum, "CONTAINER");
     new G4PVPlacement(0, G4ThreeVector(0., 0., 0.), lxe_container_logic,
@@ -313,6 +316,7 @@ void FullRingInfinity::BuildCryostat()
     // Reflectant panels
     G4Material* kapton =
         G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON");
+    kapton->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4Tubs* kapton_int_solid =
         new G4Tubs("KAPTON", inner_radius_ - kapton_thickn_, inner_radius_,
@@ -519,6 +523,7 @@ void FullRingInfinity::BuildSeparators()
 {
   // Separate LXe volume in smaller areas with teflon panels
   G4Material* teflon = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+  teflon->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   //G4double arc_sep_phi = 2 * pi * (inner_radius_ + lxe_depth_) / n_sep_phi_;
   //G4int n_sipm_in_sep_phi = arc_sep_phi / sipm_pitch_;

--- a/source/geometries/PetBox.cc
+++ b/source/geometries/PetBox.cc
@@ -142,6 +142,7 @@ void PetBox::BuildBox()
       new G4Box("BOX", box_size_/2., box_size_/2., box_size_/2.);
 
   G4Material *aluminum = G4NistManager::Instance()->FindOrBuildMaterial("G4_Al");
+  aluminum->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
   G4LogicalVolume *box_logic =
       new G4LogicalVolume(box_solid, aluminum, "BOX");
 
@@ -217,6 +218,7 @@ void PetBox::BuildBox()
       new G4Tubs("SOURCE_TUBE", 0, source_tube_ext_radius, source_tube_length/2., 0, twopi);
 
   G4Material *carbon_fiber = petmaterials::CarbonFiber();
+  carbon_fiber->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
   G4LogicalVolume *source_tube_logic =
       new G4LogicalVolume(source_tube_solid, carbon_fiber, "SOURCE_TUBE");
 
@@ -229,6 +231,7 @@ void PetBox::BuildBox()
       new G4Tubs("AIR_SOURCE_TUBE", 0, source_tube_int_radius_, air_source_tube_len/2., 0, twopi);
 
   G4Material *air = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+  air->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
   G4LogicalVolume *air_source_tube_logic =
       new G4LogicalVolume(air_source_tube_solid, air, "AIR_SOURCE_TUBE");
 
@@ -330,6 +333,7 @@ void PetBox::BuildBox()
         new G4Box("ENTRY_PANEL", entry_panel_x_size_/2., entry_panel_y_size_/2., panel_thickness_/2.);
 
     G4Material *pyrex = G4NistManager::Instance()->FindOrBuildMaterial("G4_Pyrex_Glass");
+    pyrex->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
     //pyrex->SetMaterialPropertiesTable(petopticalprops::Pyrex_vidrasa());
 
     G4LogicalVolume *entry_panel_logic =
@@ -518,6 +522,7 @@ void PetBox::BuildBox()
     G4double block_z_pos = ih_z_size_/2. + teflon_block_thick/2.;
 
     G4Material *teflon = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+    teflon->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume *teflon_block_logic =
        new G4LogicalVolume(teflon_block_solid, teflon, "TEFLON_BLOCK");


### PR DESCRIPTION
This PR overcomes a G4 bug, which causes random crashes, when an optical photon hits a material with no optical properties defined, sometimes. In nexus we used the same trick and it worked.