### PR TITLE
Make thermal electron production configurable

### DIFF
--- a/macros/PET_full_body_nest.config.mac
+++ b/macros/PET_full_body_nest.config.mac
@@ -25,6 +25,7 @@
 
 /process/optical/processActivation Scintillation false
 /PhysicsList/Petalo/nest true
+#/PhysicsList/Petalo/thermal_electrons false
 
 
 ### VERBOSITIES

--- a/source/physics_lists/PetaloPhysics.cc
+++ b/source/physics_lists/PetaloPhysics.cc
@@ -31,7 +31,8 @@
 G4_DECLARE_PHYSCONSTR_FACTORY(PetaloPhysics);
 
 PetaloPhysics::PetaloPhysics() : G4VPhysicsConstructor("PetaloPhysics"),
-                                 risetime_(false), noCompt_(false), nest_(false)
+                                 risetime_(false), noCompt_(false),
+                                 nest_(false), prod_th_el_(false)
 {
   msg_ = new G4GenericMessenger(this, "/PhysicsList/Petalo/",
                                 "Control commands of the nexus physics list.");
@@ -44,6 +45,9 @@ PetaloPhysics::PetaloPhysics() : G4VPhysicsConstructor("PetaloPhysics"),
 
   msg_->DeclareProperty("nest", nest_,
                         "If true, NEST is used for scintillation.");
+
+  msg_->DeclareProperty("thermal_electrons", prod_th_el_,
+                        "If true, NEST thermal electrons are produced.");
 }
 
 PetaloPhysics::~PetaloPhysics()
@@ -113,7 +117,7 @@ void PetaloPhysics::ConstructProcess()
     NEST::NESTProc* theNESTScintillationProcess =
       new NEST::NESTProc("S1", fElectromagnetic, petaloCalc, petalo);
     theNESTScintillationProcess->SetDetailedSecondaries(true); // this is to use the full scintillation spectrum of LXe.
-    theNESTScintillationProcess->SetStackElectrons(true); //false if only light is collected
+    theNESTScintillationProcess->SetStackElectrons(prod_th_el_); //false if only light is collected
 
     auto aParticleIterator = GetParticleIterator();
     aParticleIterator->reset();

--- a/source/physics_lists/PetaloPhysics.h
+++ b/source/physics_lists/PetaloPhysics.h
@@ -35,6 +35,8 @@ private:
 
   G4bool nest_; ///< Switch on/off NEST
 
+  G4bool prod_th_el_; ///< If true, NEST thermal electrons are produced
+
   G4GenericMessenger *msg_;
   WavelengthShifting *wls_;
   PositronAnnihilation* pos_annihil_;


### PR DESCRIPTION
This PR adds the possibility of saving or not the thermal electrons produced by NEST, because they slow down the simulation significantly.