### PR TITLE
Update package version to work with Ventura OSX

### DIFF
--- a/scripts/test_environment.yml
+++ b/scripts/test_environment.yml
@@ -1,11 +1,11 @@
 name: tests
 dependencies:
-  - python=3.8.5
-  - numpy=1.19.1
-  - pandas=1.1.3
-  - pytables=3.6.1
-  - pytest=6.1.1
-  - hypothesis=5.37.4
-  - pip=20.2.4
+  - python=3.10.8
+  - numpy=1.23.5
+  - pandas=1.5.2
+  - pytables=3.7.0
+  - pytest=7.1.2
+  - hypothesis=6.29.3
+  - pip=22.3.1
   - pip:
     - pytest-order==0.9.2

--- a/tests/pytest/vertex_test.py
+++ b/tests/pytest/vertex_test.py
@@ -14,4 +14,4 @@ def test_vertices_are_generated_in_phantom(file_name_phantom):
                        'ROD5', 'SPHERE0', 'SPHERE1', 'SPHERE2', 'SPHERE3',
                        'SPHERE4', 'SPHERE5']
 
-    assert volumes.all() in correct_volumes
+    assert all(elem in correct_volumes for elem in volumes)


### PR DESCRIPTION
The new MacOS operative system Ventura on M1 required an update of packages used in the tests. Additionally, an error is raised in one of the tests, probably due to a change in one of the packages. The assertion has been rewritten in an equivalent way, and the error disappeared.