### PR TITLE
Change ToF info in output files

### DIFF
--- a/macros/PET_full_body.config.mac
+++ b/macros/PET_full_body.config.mac
@@ -12,7 +12,6 @@
 
 /Geometry/SiPMpet/efficiency 0.2
 /Geometry/SiPMpet/visibility true
-/Geometry/SiPMpet/time_binning 5. picosecond
 /Geometry/SiPMpet/size 6. mm
 
 

--- a/macros/PET_full_body_analysis.config.mac
+++ b/macros/PET_full_body_analysis.config.mac
@@ -11,7 +11,6 @@
 
 /Geometry/SiPMpet/efficiency 0.2
 /Geometry/SiPMpet/visibility true
-/Geometry/SiPMpet/time_binning 5. picosecond
 /Geometry/SiPMpet/size 6. mm
 
 

--- a/macros/PET_full_body_nest.config.mac
+++ b/macros/PET_full_body_nest.config.mac
@@ -15,7 +15,6 @@
 
 /Geometry/SiPMpet/efficiency 0.3
 /Geometry/SiPMpet/visibility false
-/Geometry/SiPMpet/time_binning 5. picosecond
 /Geometry/SiPMpet/size 6. mm
 
 

--- a/macros/PET_full_body_nest_phantom.config.mac
+++ b/macros/PET_full_body_nest_phantom.config.mac
@@ -12,7 +12,6 @@
 
 /Geometry/SiPMpet/efficiency 0.3
 /Geometry/SiPMpet/visibility false
-/Geometry/SiPMpet/time_binning 5. picosecond
 /Geometry/SiPMpet/size 6. mm
 
 

--- a/macros/PET_full_body_sens.config.mac
+++ b/macros/PET_full_body_sens.config.mac
@@ -16,7 +16,6 @@
 /Geometry/FullRingInfinity/sens_z_max  90. mm
 
 /Geometry/SiPMpet/efficiency 0.2
-/Geometry/SiPMpet/time_binning 5. picosecond
 /Geometry/SiPMpet/size 6. mm
 
 

--- a/macros/PETit_ring.config.mac
+++ b/macros/PETit_ring.config.mac
@@ -10,7 +10,6 @@
 
 /Geometry/SiPMpet/efficiency 0.2
 /Geometry/SiPMpet/visibility true
-/Geometry/SiPMpet/time_binning 5. picosecond
 /Geometry/SiPMpet/size 6. mm
 
 ### GENERATOR

--- a/macros/PETit_tiles.config.mac
+++ b/macros/PETit_tiles.config.mac
@@ -8,7 +8,6 @@
 /Geometry/SiPMpet/efficiency 0.2
 /Geometry/SiPMpet/visibility true
 /Geometry/Tile/visibility true
-/Geometry/SiPMpet/time_binning 5. picosecond
 /Geometry/SiPMpet/size 3. mm
 
 ### GENERATOR

--- a/macros/PetBox.config.mac
+++ b/macros/PetBox.config.mac
@@ -8,7 +8,6 @@
 
 /Geometry/PetBox/tile_vis true
 /Geometry/PetBox/tile_refl 0.
-/Geometry/PetBox/sipm_time_binning 5. picosecond
 /Geometry/PetBox/sipm_pde 0.3
 
 ### GENERATOR

--- a/macros/PetBox_nest.config.mac
+++ b/macros/PetBox_nest.config.mac
@@ -7,7 +7,6 @@
 
 /Geometry/PetBox/tile_vis true
 /Geometry/PetBox/tile_refl 0.
-/Geometry/PetBox/sipm_time_binning 5. picosecond
 /Geometry/PetBox/sipm_pde 0.3
 
 ### GENERATOR

--- a/source/actions/PetSensorsEventAction.cc
+++ b/source/actions/PetSensorsEventAction.cc
@@ -116,20 +116,13 @@ void PetSensorsEventAction::EndOfEventAction(const G4Event *event)
         PetSensorHit* hit = dynamic_cast<PetSensorHit*>(hits->GetHit(i));
         if (!hit) continue;
 
-        // Reject TOF hits
-        if (hit->GetSnsID() >= 0) {
-          const std::map<G4double, G4int>& wvfm = hit->GetHistogram();
-          std::map<G4double, G4int>::const_iterator it;
-
-          for (it = wvfm.begin(); it != wvfm.end(); ++it) {
-            amplitude = amplitude + (*it).second;
-          }
-        } else continue;
+        amplitude += hit->GetDetPhotons();
       }
+
       if (amplitude>min_charge_){
         charge_above_th = true;
       }
-  }
+    }
 
     PetaloPersistencyManager *pm = dynamic_cast<PetaloPersistencyManager *>(G4VPersistencyManager::GetPersistencyManager());
 

--- a/source/actions/PetSensorsEventAction.cc
+++ b/source/actions/PetSensorsEventAction.cc
@@ -9,10 +9,10 @@
 
 #include "PetSensorsEventAction.h"
 #include "PetaloPersistencyManager.h"
+#include "ToFSD.h"
 
 #include "nexus/Trajectory.h"
 #include "nexus/FactoryBase.h"
-#include "nexus/SensorSD.h"
 
 #include <G4Event.hh>
 #include <G4VVisManager.hh>
@@ -103,21 +103,21 @@ void PetSensorsEventAction::EndOfEventAction(const G4Event *event)
     G4SDManager* sdmgr = G4SDManager::GetSDMpointer();
     G4HCtable* hct = sdmgr->GetHCtable();
 
-    // Get only the SensorHitsCollection --> 1
+    // Get only the PetSensorHitsCollection --> 1
     G4String hcname = hct->GetHCname(1);
     G4String sdname = hct->GetSDname(1);
     int hcid = sdmgr->GetCollectionID(sdname+"/"+hcname);
 
-    if (hcname == SensorSD::GetCollectionUniqueName()){
+    if (hcname == ToFSD::GetCollectionUniqueName()){
       G4VHitsCollection* SensHits = hce->GetHC(hcid);
-      SensorHitsCollection* hits = dynamic_cast<SensorHitsCollection*>(SensHits);
+      PetSensorHitsCollection* hits = dynamic_cast<PetSensorHitsCollection*>(SensHits);
       if (!hits) return;
       for (size_t i=0; i<hits->entries(); i++) {
-        SensorHit* hit = dynamic_cast<SensorHit*>(hits->GetHit(i));
+        PetSensorHit* hit = dynamic_cast<PetSensorHit*>(hits->GetHit(i));
         if (!hit) continue;
 
         // Reject TOF hits
-        if (hit->GetPmtID() >= 0) {
+        if (hit->GetSnsID() >= 0) {
           const std::map<G4double, G4int>& wvfm = hit->GetHistogram();
           std::map<G4double, G4int>::const_iterator it;
 

--- a/source/geometries/PetBox.cc
+++ b/source/geometries/PetBox.cc
@@ -105,13 +105,6 @@ PetBox::PetBox() : GeometryBase(),
   msg_->DeclareProperty("single_tile_coinc_plane", single_tile_coinc_plane_,
                         "If 1, one tile centered in coinc plane");
 
-  G4GenericMessenger::Command &time_cmd =
-      msg_->DeclareProperty("sipm_time_binning", time_binning_,
-                            "Time binning for the sensor");
-  time_cmd.SetUnitCategory("Time");
-  time_cmd.SetParameterName("sipm_time_binning", false);
-  time_cmd.SetRange("sipm_time_binning>0.");
-
   msg_->DeclareProperty("add_teflon_block", add_teflon_block_,
     "Boolean to add a teflon block that reduces the xenon volume");
 
@@ -303,7 +296,6 @@ void PetBox::BuildBox()
   // Construct the tile for the distances in the active
   tile_->SetTileVisibility(tile_vis_);
   tile_->SetTileReflectivity(tile_refl_);
-  tile_->SetTimeBinning(time_binning_);
 
   tile_->Construct();
   tile_thickn_ = tile_->GetDimensions().z();
@@ -329,7 +321,6 @@ void PetBox::BuildBox()
     tile2_->SetBoxGeom(1);
     tile2_->SetTileVisibility(tile_vis_);
     tile2_->SetTileReflectivity(tile_refl_);
-    tile2_->SetTimeBinning(time_binning_);
 
     tile2_->Construct();
     tile2_thickn_ = tile2_->GetDimensions().z();

--- a/source/geometries/PetBox.h
+++ b/source/geometries/PetBox.h
@@ -60,7 +60,6 @@ private:
 
   G4String tile_type_d_, tile_type_c_;
   G4bool single_tile_coinc_plane_;
-  G4double time_binning_;
 
   G4double box_size_, box_thickness_;
 

--- a/source/geometries/SiPMFBKVUV.cc
+++ b/source/geometries/SiPMFBKVUV.cc
@@ -31,12 +31,10 @@ using namespace CLHEP;
 SiPMFBKVUV::SiPMFBKVUV() : GeometryBase(),
                            visibility_(1),
                            eff_(1.),
-                           time_binning_(5. * picosecond),
                            sensor_depth_(-1),
                            mother_depth_(0),
                            naming_order_(0),
                            box_geom_(0)
-
 {
 }
 
@@ -122,7 +120,6 @@ void SiPMFBKVUV::Construct()
     sipmsd->SetDetectorVolumeDepth(sensor_depth_);
     sipmsd->SetMotherVolumeDepth(mother_depth_);
     sipmsd->SetDetectorNamingOrder(naming_order_);
-    sipmsd->SetTimeBinning(time_binning_);
     sipmsd->SetBoxGeom(box_geom_);
 
     G4SDManager::GetSDMpointer()->AddNewDetector(sipmsd);

--- a/source/geometries/SiPMFBKVUV.h
+++ b/source/geometries/SiPMFBKVUV.h
@@ -29,7 +29,6 @@ public:
 
   void SetVisibility(G4bool vis);
   void SetPDE(G4double eff);
-  void SetTimeBinning(G4double time_binning);
   void SetSensorDepth(G4int sensor_depth);
   void SetMotherDepth(G4int mother_depth);
   void SetNamingOrder(G4int naming_order);
@@ -41,7 +40,6 @@ private:
   // PDE for the sensor
   G4double eff_;
 
-  G4double time_binning_;
   G4int sensor_depth_;
   G4int mother_depth_;
   G4int naming_order_;
@@ -56,11 +54,6 @@ inline void SiPMFBKVUV::SetVisibility(G4bool vis)
 inline void SiPMFBKVUV::SetPDE(G4double eff)
 {
   eff_ = eff;
-}
-
-inline void SiPMFBKVUV::SetTimeBinning(G4double time_binning)
-{
-  time_binning_ = time_binning;
 }
 
 inline void SiPMFBKVUV::SetSensorDepth(G4int sensor_depth)

--- a/source/geometries/SiPMHamamatsuBlue.cc
+++ b/source/geometries/SiPMHamamatsuBlue.cc
@@ -29,12 +29,10 @@ using namespace CLHEP;
 
 SiPMHamamatsuBlue::SiPMHamamatsuBlue() : GeometryBase(),
                                          visibility_(1),
-                                         time_binning_(5. * picosecond),
                                          sensor_depth_(-1),
                                          mother_depth_(0),
                                          naming_order_(0),
                                          box_geom_(0)
-
 {
 }
 
@@ -125,7 +123,6 @@ void SiPMHamamatsuBlue::Construct()
     sipmsd->SetDetectorVolumeDepth(sensor_depth_);
     sipmsd->SetMotherVolumeDepth(mother_depth_);
     sipmsd->SetDetectorNamingOrder(naming_order_);
-    sipmsd->SetTimeBinning(time_binning_);
     sipmsd->SetBoxGeom(box_geom_);
 
     G4SDManager::GetSDMpointer()->AddNewDetector(sipmsd);

--- a/source/geometries/SiPMHamamatsuBlue.h
+++ b/source/geometries/SiPMHamamatsuBlue.h
@@ -31,7 +31,6 @@ public:
   void Construct();
 
   void SetVisibility(G4bool vis);
-  void SetTimeBinning(G4double time_binning);
   void SetSensorDepth(G4int sensor_depth);
   void SetMotherDepth(G4int mother_depth);
   void SetNamingOrder(G4int naming_order);
@@ -40,7 +39,6 @@ public:
 private:
   G4bool visibility_;
 
-  G4double time_binning_;
   G4int sensor_depth_;
   G4int mother_depth_;
   G4int naming_order_;
@@ -50,11 +48,6 @@ private:
 inline void SiPMHamamatsuBlue::SetVisibility(G4bool vis)
 {
   visibility_ = vis;
-}
-
-inline void SiPMHamamatsuBlue::SetTimeBinning(G4double time_binning)
-{
-  time_binning_ = time_binning;
 }
 
 inline void SiPMHamamatsuBlue::SetSensorDepth(G4int sensor_depth)

--- a/source/geometries/SiPMHamamatsuVUV.cc
+++ b/source/geometries/SiPMHamamatsuVUV.cc
@@ -31,12 +31,10 @@ using namespace CLHEP;
 
 SiPMHamamatsuVUV::SiPMHamamatsuVUV() : GeometryBase(),
                                        visibility_(1),
-                                       time_binning_(5. * picosecond),
                                        sensor_depth_(-1),
                                        mother_depth_(0),
                                        naming_order_(0),
                                        box_geom_(0)
-
 {
 }
 
@@ -136,7 +134,6 @@ void SiPMHamamatsuVUV::Construct()
     sipmsd->SetDetectorVolumeDepth(sensor_depth_);
     sipmsd->SetMotherVolumeDepth(mother_depth_);
     sipmsd->SetDetectorNamingOrder(naming_order_);
-    sipmsd->SetTimeBinning(time_binning_);
     sipmsd->SetBoxGeom(box_geom_);
 
     G4SDManager::GetSDMpointer()->AddNewDetector(sipmsd);

--- a/source/geometries/SiPMHamamatsuVUV.h
+++ b/source/geometries/SiPMHamamatsuVUV.h
@@ -28,7 +28,6 @@ public:
   void Construct();
 
   void SetVisibility(G4bool vis);
-  void SetTimeBinning(G4double time_binning);
   void SetSensorDepth(G4int sensor_depth);
   void SetMotherDepth(G4int mother_depth);
   void SetNamingOrder(G4int naming_order);
@@ -37,7 +36,6 @@ public:
 private:
   G4bool visibility_;
 
-  G4double time_binning_;
   G4int sensor_depth_;
   G4int mother_depth_;
   G4int naming_order_;
@@ -47,11 +45,6 @@ private:
 inline void SiPMHamamatsuVUV::SetVisibility(G4bool vis)
 {
   visibility_ = vis;
-}
-
-inline void SiPMHamamatsuVUV::SetTimeBinning(G4double time_binning)
-{
-  time_binning_ = time_binning;
 }
 
 inline void SiPMHamamatsuVUV::SetSensorDepth(G4int sensor_depth)

--- a/source/geometries/SiPMpet.cc
+++ b/source/geometries/SiPMpet.cc
@@ -34,18 +34,11 @@ using namespace nexus;
 using namespace CLHEP;
 
 SiPMpet::SiPMpet() : GeometryBase(),
-                     visibility_(0),
-                     time_binning_(5. * picosecond)
+                     visibility_(0)
 {
   /// Messenger
   msg_ = new G4GenericMessenger(this, "/Geometry/SiPMpet/", "Control commands of geometry.");
   msg_->DeclareProperty("SiPMpet_vis", visibility_, "SiPMpet Visibility");
-
-  G4GenericMessenger::Command &time_cmd =
-      msg_->DeclareProperty("time_binning", time_binning_, "Time binning for the sensor");
-  time_cmd.SetUnitCategory("Time");
-  time_cmd.SetParameterName("time_binning", false);
-  time_cmd.SetRange("time_binning>0.");
 }
 
 SiPMpet::~SiPMpet()
@@ -175,7 +168,6 @@ void SiPMpet::Construct()
     ToFSD *sipmsd = new ToFSD(sdname);
     sipmsd->SetDetectorVolumeDepth(0);
     sipmsd->SetDetectorNamingOrder(1000.);
-    sipmsd->SetTimeBinning(time_binning_);
     sipmsd->SetMotherVolumeDepth(1);
 
     G4SDManager::GetSDMpointer()->AddNewDetector(sipmsd);

--- a/source/geometries/SiPMpet.h
+++ b/source/geometries/SiPMpet.h
@@ -40,8 +40,6 @@ private:
 
   // Messenger for the definition of control commands
   G4GenericMessenger *msg_;
-
-  G4double time_binning_;
 };
 
 #endif

--- a/source/geometries/SiPMpetFBK.cc
+++ b/source/geometries/SiPMpetFBK.cc
@@ -34,7 +34,6 @@ SiPMpetFBK::SiPMpetFBK() : GeometryBase(),
                            visibility_(0),
                            refr_index_(1.54),
                            eff_(1.),
-                           time_binning_(5. * picosecond),
                            sipm_size_(3. * mm),
                            sensor_depth_(-1),
                            mother_depth_(0),
@@ -46,12 +45,6 @@ SiPMpetFBK::SiPMpetFBK() : GeometryBase(),
   msg_->DeclareProperty("visibility", visibility_, "SiPMpet Visibility");
   msg_->DeclareProperty("refr_index", refr_index_, "Refraction index for epoxy");
   msg_->DeclareProperty("efficiency", eff_, "Efficiency of SiPM");
-
-  G4GenericMessenger::Command &time_cmd =
-      msg_->DeclareProperty("time_binning", time_binning_, "Time binning for the sensor");
-  time_cmd.SetUnitCategory("Time");
-  time_cmd.SetParameterName("time_binning", false);
-  time_cmd.SetRange("time_binning>0.");
 
   G4GenericMessenger::Command &size_cmd =
       msg_->DeclareProperty("size", sipm_size_, "Size of SiPMs");
@@ -153,7 +146,6 @@ void SiPMpetFBK::Construct()
     sipmsd->SetDetectorVolumeDepth(sensor_depth_);
     sipmsd->SetMotherVolumeDepth(mother_depth_);
     sipmsd->SetDetectorNamingOrder(naming_order_);
-    sipmsd->SetTimeBinning(time_binning_);
     G4SDManager::GetSDMpointer()->AddNewDetector(sipmsd);
     active_logic->SetSensitiveDetector(sipmsd);
   }

--- a/source/geometries/SiPMpetFBK.h
+++ b/source/geometries/SiPMpetFBK.h
@@ -47,7 +47,7 @@ private:
   // PDE for the sensor
   G4double eff_;
 
-  G4double time_binning_, sipm_size_;
+  G4double sipm_size_;
 
   // Messenger for the definition of control commands
   G4GenericMessenger *msg_;

--- a/source/geometries/SiPMpetTPB.cc
+++ b/source/geometries/SiPMpetTPB.cc
@@ -35,8 +35,7 @@ SiPMpetTPB::SiPMpetTPB() : GeometryBase(),
                            visibility_(0),
                            refr_index_(1.),
                            decay_time_(2.2 * nanosecond),
-                           phys_(1),
-                           time_binning_(5. * picosecond)
+                           phys_(1)
 {
   /// Messenger
   msg_ = new G4GenericMessenger(this, "/Geometry/SiPMpet/", "Control commands of geometry.");
@@ -51,12 +50,6 @@ SiPMpetTPB::SiPMpetTPB() : GeometryBase(),
   decay_time_cmd.SetUnitCategory("Decay time of TPB");
   decay_time_cmd.SetParameterName("decay_time", false);
   decay_time_cmd.SetRange("decay_time>0.");
-
-  G4GenericMessenger::Command &time_cmd =
-      msg_->DeclareProperty("time_binning", time_binning_, "Time binning for the sensor");
-  time_cmd.SetUnitCategory("Time");
-  time_cmd.SetParameterName("time_binning", false);
-  time_cmd.SetRange("time_binning>0.");
 }
 
 SiPMpetTPB::~SiPMpetTPB()
@@ -219,7 +212,6 @@ void SiPMpetTPB::Construct()
     ToFSD *sipmsd = new ToFSD(sdname);
     sipmsd->SetDetectorVolumeDepth(0);
     sipmsd->SetDetectorNamingOrder(1000.);
-    sipmsd->SetTimeBinning(time_binning_);
     //    sipmsd->SetMotherVolumeDepth(1);
     //      sipmsd->SetGrandMotherVolumeDepth(3);
     sipmsd->SetMotherVolumeDepth(2);

--- a/source/geometries/SiPMpetTPB.h
+++ b/source/geometries/SiPMpetTPB.h
@@ -41,8 +41,6 @@ private:
 
   G4bool phys_;
 
-  G4double time_binning_;
-
   // Messenger for the definition of control commands
   G4GenericMessenger *msg_;
 };

--- a/source/geometries/SiPMpetVUV.cc
+++ b/source/geometries/SiPMpetVUV.cc
@@ -34,7 +34,6 @@ SiPMpetVUV::SiPMpetVUV() : GeometryBase(),
                            visibility_(0),
                            refr_index_(1.6),
                            eff_(1.),
-                           time_binning_(5.*picosecond),
                            sipm_size_(3. * mm),
                            sensor_depth_(-1),
                            mother_depth_(0),
@@ -45,12 +44,6 @@ SiPMpetVUV::SiPMpetVUV() : GeometryBase(),
   msg_->DeclareProperty("visibility", visibility_, "SiPMpet Visibility");
   msg_->DeclareProperty("refr_index", refr_index_, "Refraction index for sipm window");
   msg_->DeclareProperty("efficiency", eff_, "Efficiency of SiPM");
-
-  G4GenericMessenger::Command &time_cmd =
-      msg_->DeclareProperty("time_binning", time_binning_, "Time binning for the sensor");
-  time_cmd.SetUnitCategory("Time");
-  time_cmd.SetParameterName("time_binning", false);
-  time_cmd.SetRange("time_binning>0.");
 
   G4GenericMessenger::Command &size_cmd =
       msg_->DeclareProperty("size", sipm_size_, "Size of SiPMs");
@@ -160,7 +153,6 @@ void SiPMpetVUV::Construct()
     sipmsd->SetDetectorVolumeDepth(sensor_depth_);
     sipmsd->SetMotherVolumeDepth(mother_depth_);
     sipmsd->SetDetectorNamingOrder(naming_order_);
-    sipmsd->SetTimeBinning(time_binning_);
     G4SDManager::GetSDMpointer()->AddNewDetector(sipmsd);
     active_logic->SetSensitiveDetector(sipmsd);
   }

--- a/source/geometries/SiPMpetVUV.h
+++ b/source/geometries/SiPMpetVUV.h
@@ -46,7 +46,6 @@ private:
   // Messenger for the definition of control commands
   G4GenericMessenger *msg_;
 
-  G4double time_binning_;
   G4double sipm_size_;
   G4int sensor_depth_, mother_depth_, naming_order_;
 };

--- a/source/geometries/SiPMquadFBK.cc
+++ b/source/geometries/SiPMquadFBK.cc
@@ -33,20 +33,13 @@ using namespace CLHEP;
 SiPMquadFBK::SiPMquadFBK() : GeometryBase(),
                              visibility_(0),
                              refr_index_(1.54),
-                             eff_(1.),
-                             time_binning_(5. * picosecond)
+                             eff_(1.)
 {
   /// Messenger
   msg_ = new G4GenericMessenger(this, "/Geometry/SiPMpet/", "Control commands of geometry.");
   msg_->DeclareProperty("visibility", visibility_, "SiPMpet Visibility");
   msg_->DeclareProperty("refr_index", refr_index_, "Refraction index for epoxy");
   msg_->DeclareProperty("efficiency", eff_, "Efficiency of SiPM");
-
-  G4GenericMessenger::Command &time_cmd =
-      msg_->DeclareProperty("time_binning", time_binning_, "Time binning for the sensor");
-  time_cmd.SetUnitCategory("Time");
-  time_cmd.SetParameterName("time_binning", false);
-  time_cmd.SetRange("time_binning>0.");
 }
 
 SiPMquadFBK::~SiPMquadFBK()
@@ -131,7 +124,6 @@ void SiPMquadFBK::Construct()
     ToFSD *sipmsd = new ToFSD(sdname);
     sipmsd->SetDetectorVolumeDepth(0);
     sipmsd->SetDetectorNamingOrder(1000.);
-    sipmsd->SetTimeBinning(time_binning_);
     sipmsd->SetMotherVolumeDepth(1);
 
     G4SDManager::GetSDMpointer()->AddNewDetector(sipmsd);

--- a/source/geometries/SiPMquadFBK.h
+++ b/source/geometries/SiPMquadFBK.h
@@ -37,8 +37,6 @@ private:
   // PDE for the sensor
   G4double eff_;
 
-  G4double time_binning_;
-
   // Messenger for the definition of control commands
   G4GenericMessenger *msg_;
 };

--- a/source/geometries/TileFBK.cc
+++ b/source/geometries/TileFBK.cc
@@ -68,7 +68,6 @@ void TileFBK::Construct()
   sipm_->SetMotherDepth(2);
   sipm_->SetBoxGeom(GetBoxGeom());
   sipm_->SetVisibility(GetTileVisibility());
-  sipm_->SetTimeBinning(GetTimeBinning());
   sipm_->SetPDE(GetPDE());
 
   sipm_->Construct();

--- a/source/geometries/TileGeometryBase.h
+++ b/source/geometries/TileGeometryBase.h
@@ -31,9 +31,6 @@ public:
   void SetTileReflectivity(G4double refl);
   G4double GetTileReflectivity() const;
 
-  void SetTimeBinning(G4double tb);
-  G4double GetTimeBinning() const;
-
   void SetPDE(G4double eff);
   G4double GetPDE() const;
 
@@ -51,7 +48,6 @@ private:
   G4int box_geom_;
   G4bool tile_vis_;
   G4double tile_refl_;
-  G4double time_binning_;
   G4double sipm_pde_;
 };
 
@@ -68,9 +64,6 @@ inline G4bool TileGeometryBase::GetTileVisibility() const { return tile_vis_; }
 
 inline void TileGeometryBase::SetTileReflectivity(G4double refl) { tile_refl_ = refl; }
 inline G4double TileGeometryBase::GetTileReflectivity() const { return tile_refl_; }
-
-inline void TileGeometryBase::SetTimeBinning(G4double tb) { time_binning_ = tb; }
-inline G4double TileGeometryBase::GetTimeBinning() const { return time_binning_; }
 
 inline void TileGeometryBase::SetPDE(G4double eff) { sipm_pde_ = eff; }
 inline G4double TileGeometryBase::GetPDE() const { return sipm_pde_; }

--- a/source/geometries/TileHamamatsuBlue.cc
+++ b/source/geometries/TileHamamatsuBlue.cc
@@ -73,7 +73,6 @@ void TileHamamatsuBlue::Construct()
   sipm_->SetMotherDepth(2);
   sipm_->SetBoxGeom(GetBoxGeom());
   sipm_->SetVisibility(GetTileVisibility());
-  sipm_->SetTimeBinning(GetTimeBinning());
 
   sipm_->Construct();
   G4ThreeVector sipm_dim = sipm_->GetDimensions();

--- a/source/geometries/TileHamamatsuVUV.cc
+++ b/source/geometries/TileHamamatsuVUV.cc
@@ -74,7 +74,6 @@ void TileHamamatsuVUV::Construct()
   sipm_->SetBoxGeom(GetBoxGeom());
   // The SiPMs will have the same visibility as the tile
   sipm_->SetVisibility(GetTileVisibility());
-  sipm_->SetTimeBinning(GetTimeBinning());
 
   sipm_->Construct();
   G4ThreeVector sipm_dim = sipm_->GetDimensions();

--- a/source/persistency/HDF5Writer.cc
+++ b/source/persistency/HDF5Writer.cc
@@ -106,17 +106,18 @@ void HDF5Writer::WriteSensorDataInfo(int evt_number, unsigned int sensor_id, uns
   ismp_++;
 }
 
-void HDF5Writer::WriteSensorTofInfo(int evt_number, int sensor_id, unsigned int time_bin, unsigned int charge)
+void HDF5Writer::WriteSensorTofInfo(int evt_number, int sensor_id, float time, unsigned int track_id)
 {
   sns_tof_t snsTof;
   snsTof.event_id = evt_number;
   snsTof.sensor_id = sensor_id;
-  snsTof.time_bin = time_bin;
-  snsTof.charge = charge;
+  snsTof.time = time;
+  snsTof.track_id = track_id;
   writeSnsTof(&snsTof, snsTofTable_, memtypeSnsTof_, ismp_tof_);
 
   ismp_tof_++;
 }
+
 
 void HDF5Writer::WriteHitInfo(int evt_number, int particle_indx, float hit_position_x, float hit_position_y, float hit_position_z, float hit_time, float hit_energy, const char* label)
 {

--- a/source/persistency/HDF5Writer.h
+++ b/source/persistency/HDF5Writer.h
@@ -31,7 +31,7 @@ public:
 
   void WriteRunInfo(const char *param_key, const char *param_value);
   void WriteSensorDataInfo(int evt_number, unsigned int sensor_id, unsigned int charge);
-  void WriteSensorTofInfo(int evt_number, int sensor_id, unsigned int time_bin, unsigned int charge);
+  void WriteSensorTofInfo(int evt_number, int sensor_id, float time, unsigned int track_id);
   void WriteHitInfo(int evt_number, int particle_indx, float hit_position_x, float hit_position_y, float hit_position_z, float hit_time, float hit_energy, const char *label);
   void WriteParticleInfo(int evt_number, int particle_indx, const char *particle_name, char primary, int mother_id, float initial_vertex_x, float initial_vertex_y, float initial_vertex_z, float initial_vertex_t, float final_vertex_x, float final_vertex_y, float final_vertex_z, float final_vertex_t, const char *initial_volume, const char *final_volume, float momentum_x, float momentum_y, float momentum_z, float final_momentum_x, float final_momentum_y, float final_momentum_z, float kin_energy, float length, const char *creator_proc, const char *final_proc);
   void WriteSensorPosInfo(unsigned int sensor_id, const char *sensor_name, float x, float y, float z);
@@ -73,8 +73,8 @@ private:
   size_t memtypeChargeData_;
 
   size_t irun_;     ///< counter for configuration parameters
-  size_t ismp_;     ///< counter for written waveform samples
-  size_t ismp_tof_; ///< counter for written waveform samples (first bins only)
+  size_t ismp_;     ///< counter for total charge
+  size_t ismp_tof_; ///< counter for waveforms (first bins only)
   size_t ihit_;     ///< counter for true information
   size_t ipart_;    ///< counter for particle information
   size_t ipos_;     ///< counter for sensor positions

--- a/source/persistency/HDF5Writer.h
+++ b/source/persistency/HDF5Writer.h
@@ -74,7 +74,7 @@ private:
 
   size_t irun_;     ///< counter for configuration parameters
   size_t ismp_;     ///< counter for total charge
-  size_t ismp_tof_; ///< counter for waveforms (first bins only)
+  size_t ismp_tof_; ///< counter for waveforms (first photons only)
   size_t ihit_;     ///< counter for true information
   size_t ipart_;    ///< counter for particle information
   size_t ipos_;     ///< counter for sensor positions

--- a/source/persistency/PetaloPersistencyManager.cc
+++ b/source/persistency/PetaloPersistencyManager.cc
@@ -359,7 +359,7 @@ void PetaloPersistencyManager::StoreSensorHits(G4VHitsCollection* hc)
     std::vector<double > value;
     int count =0;
     std::ostringstream strs;
-    strs << hit->GetPmtID();
+    strs << hit->GetSnsID();
     std::string sens_id = strs.str();
     //   G4cout << "Longitud = " << wvls.size() << G4endl;
     for (w = wvls.begin(); w != wvls.end(); ++w) {
@@ -461,8 +461,6 @@ G4bool PetaloPersistencyManager::Store(const G4Run*)
   h5writer_->WriteRunInfo(key, std::to_string(num_events).c_str());
   key = "saved_events";
   h5writer_->WriteRunInfo(key, std::to_string(saved_evts_).c_str());
-  key = "tof_bin_size";
-  h5writer_->WriteRunInfo(key, (std::to_string(tof_bin_size_/picosecond)+" ps").c_str());
 
   if (save_int_e_numb_) {
     key = "interacting_events";

--- a/source/persistency/hdf5_functions.cc
+++ b/source/persistency/hdf5_functions.cc
@@ -36,8 +36,8 @@ hsize_t createSensorTofType()
   hsize_t memtype = H5Tcreate (H5T_COMPOUND, sizeof (sns_tof_t));
   H5Tinsert (memtype, "event_id", HOFFSET (sns_tof_t, event_id), H5T_NATIVE_INT32);
   H5Tinsert (memtype, "sensor_id" , HOFFSET (sns_tof_t, sensor_id) , H5T_NATIVE_INT);
-  H5Tinsert (memtype, "time_bin" , HOFFSET (sns_tof_t, time_bin) , H5T_NATIVE_UINT);
-  H5Tinsert (memtype, "charge" , HOFFSET (sns_tof_t, charge) , H5T_NATIVE_UINT);
+  H5Tinsert (memtype, "time" , HOFFSET (sns_tof_t, time) , H5T_NATIVE_FLOAT);
+  H5Tinsert (memtype, "track_id" , HOFFSET (sns_tof_t, track_id) , H5T_NATIVE_UINT);
   return memtype;
 }
 

--- a/source/persistency/hdf5_functions.cc
+++ b/source/persistency/hdf5_functions.cc
@@ -1,7 +1,7 @@
 // ----------------------------------------------------------------------------
 // petalosim | hdf5_functions.cc
 //
-// Collection of functions to create h5 tables for nexus output.
+// Collection of functions to create h5 tables for petalosim output.
 //
 // The PETALO Collaboration
 // ----------------------------------------------------------------------------

--- a/source/persistency/hdf5_functions.h
+++ b/source/persistency/hdf5_functions.h
@@ -29,8 +29,8 @@
   typedef struct{
     int32_t event_id;
     int sensor_id;
-    unsigned int time_bin;
-    unsigned int charge;
+    float time;
+    unsigned int track_id;
   } sns_tof_t;
 
   typedef struct{

--- a/source/persistency/hdf5_functions.h
+++ b/source/persistency/hdf5_functions.h
@@ -1,7 +1,7 @@
 // ----------------------------------------------------------------------------
 // petalosim | hdf5_functions.h
 //
-// Collection of functions to create h5 tables for nexus output.
+// Collection of functions to create h5 tables for petalosim output.
 //
 // The PETALO Collaboration
 // ----------------------------------------------------------------------------
@@ -28,7 +28,7 @@
 
   typedef struct{
     int32_t event_id;
-    int sensor_id;
+    unsigned int sensor_id;
     float time;
     unsigned int track_id;
   } sns_tof_t;

--- a/source/sensdet/PetSensorHit.cc
+++ b/source/sensdet/PetSensorHit.cc
@@ -1,0 +1,89 @@
+// ----------------------------------------------------------------------------
+// petalosim | PetSensorHit.cc
+//
+// This class describes the charge detected by a photosensor.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#include "PetSensorHit.h"
+
+
+using namespace nexus;
+
+
+G4Allocator<PetSensorHit> PetSensorHitAllocator;
+
+
+
+PetSensorHit::PetSensorHit():
+  G4VHit(), sns_id_(-1.), bin_size_(0.)
+{
+}
+
+
+
+PetSensorHit::PetSensorHit(G4int id, const G4ThreeVector& position, G4double bin_size):
+  G4VHit(), sns_id_(id),  bin_size_(bin_size), position_(position)
+{
+}
+
+
+
+PetSensorHit::~PetSensorHit()
+{
+}
+
+
+
+PetSensorHit::PetSensorHit(const PetSensorHit& other): G4VHit()
+{
+  *this = other;
+}
+
+
+
+const PetSensorHit& PetSensorHit::operator=(const PetSensorHit& other)
+{
+  sns_id_    = other.sns_id_;
+  bin_size_  = other.bin_size_;
+  position_  = other.position_;
+  histogram_ = other.histogram_;
+
+  return *this;
+}
+
+
+
+G4int PetSensorHit::operator==(const PetSensorHit& other) const
+{
+  return (this==&other) ? 1 : 0;
+}
+
+
+
+void PetSensorHit::SetBinSize(G4double bin_size)
+{
+  if (histogram_.size() == 0) {
+    bin_size_ = bin_size;
+  }
+  else {
+    G4String msg = "A PetSensorHit cannot be rebinned once it has been filled.";
+    G4Exception("[PetSensorHit]", "SetBinSize()", JustWarning, msg);
+  }
+}
+
+
+
+void PetSensorHit::Fill(G4double time, G4int counts)
+{
+  G4double time_bin = floor(time/bin_size_) * bin_size_;
+  histogram_[time_bin] += counts;
+}
+
+
+void PetSensorHit::AddPhoton(G4double time, G4int track_id)
+{
+  phot_[time] = track_id;
+}
+

--- a/source/sensdet/PetSensorHit.cc
+++ b/source/sensdet/PetSensorHit.cc
@@ -9,9 +9,6 @@
 #include "PetSensorHit.h"
 
 
-using namespace nexus;
-
-
 G4Allocator<PetSensorHit> PetSensorHitAllocator;
 
 

--- a/source/sensdet/PetSensorHit.cc
+++ b/source/sensdet/PetSensorHit.cc
@@ -14,14 +14,14 @@ G4Allocator<PetSensorHit> PetSensorHitAllocator;
 
 
 PetSensorHit::PetSensorHit():
-  G4VHit(), sns_id_(-1.), bin_size_(0.)
+  G4VHit(), counts_(0), sns_id_(-1.)
 {
 }
 
 
 
-PetSensorHit::PetSensorHit(G4int id, const G4ThreeVector& position, G4double bin_size):
-  G4VHit(), sns_id_(id),  bin_size_(bin_size), position_(position)
+PetSensorHit::PetSensorHit(G4int id, const G4ThreeVector& position):
+  G4VHit(), counts_(0), sns_id_(id), position_(position)
 {
 }
 
@@ -43,9 +43,9 @@ PetSensorHit::PetSensorHit(const PetSensorHit& other): G4VHit()
 const PetSensorHit& PetSensorHit::operator=(const PetSensorHit& other)
 {
   sns_id_    = other.sns_id_;
-  bin_size_  = other.bin_size_;
   position_  = other.position_;
-  histogram_ = other.histogram_;
+  counts_    = other.counts_;
+  phot_      = other.phot_;
 
   return *this;
 }
@@ -57,26 +57,6 @@ G4int PetSensorHit::operator==(const PetSensorHit& other) const
   return (this==&other) ? 1 : 0;
 }
 
-
-
-void PetSensorHit::SetBinSize(G4double bin_size)
-{
-  if (histogram_.size() == 0) {
-    bin_size_ = bin_size;
-  }
-  else {
-    G4String msg = "A PetSensorHit cannot be rebinned once it has been filled.";
-    G4Exception("[PetSensorHit]", "SetBinSize()", JustWarning, msg);
-  }
-}
-
-
-
-void PetSensorHit::Fill(G4double time, G4int counts)
-{
-  G4double time_bin = floor(time/bin_size_) * bin_size_;
-  histogram_[time_bin] += counts;
-}
 
 
 void PetSensorHit::AddPhoton(G4double time, G4int track_id)

--- a/source/sensdet/PetSensorHit.h
+++ b/source/sensdet/PetSensorHit.h
@@ -1,0 +1,110 @@
+// ----------------------------------------------------------------------------
+// petalosim | PETSensorHit.h
+//
+// This class describes the charge detected by a photosensor.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef PET_SNS_HIT_H
+#define PET_SNS_HIT_H
+
+#include <G4VHit.hh>
+#include <G4THitsCollection.hh>
+#include <G4Allocator.hh>
+#include <G4ThreeVector.hh>
+
+
+namespace nexus {
+
+  class PetSensorHit: public G4VHit
+  {
+  public:
+    /// Default constructor
+    PetSensorHit();
+    /// Constructor providing the detector ID and position
+    PetSensorHit(G4int ID, const G4ThreeVector& position, G4double bin_size);
+    /// Copy-constructor
+    PetSensorHit(const PetSensorHit&);
+    /// Destructor
+    ~PetSensorHit();
+
+    /// Assignement operator
+    const PetSensorHit& operator=(const PetSensorHit&);
+    /// Equality operator
+    G4int operator==(const PetSensorHit&) const;
+
+    /// Memory allocation
+    void* operator new(size_t);
+    /// Memory deallocation
+     void operator delete(void*);
+
+    /// Returns the detector ID code
+    G4int GetSnsID() const;
+    /// Sets the detector ID code
+    void  SetSnsID(G4int);
+
+    /// Returns the position of the detector
+    G4ThreeVector GetPosition() const;
+    /// Sets the position of the detector
+    void SetPosition(const G4ThreeVector&);
+
+    /// Returns the bin size of the histogram
+    G4double GetBinSize() const;
+    /// Sets the bin size of the histogram. This can only be done
+    /// while the histogram is empty (rebinning is not supported).
+    void SetBinSize(G4double);
+
+    /// Adds counts to a given time bin
+    void Fill(G4double time, G4int counts=1);
+    void AddPhoton(G4double time, G4int track_id);
+
+    const std::map<G4double, G4int>& GetHistogram() const;
+    const std::map<G4double, G4int>& GetPhotonMap() const;
+
+  private:
+    G4int sns_id_;           ///< Detector ID number
+    G4double bin_size_;      ///< Size of time bin
+    G4ThreeVector position_; ///< Detector position
+
+    /// Sparse histogram with number of photons detected per time bin
+    std::map<G4double, G4int> histogram_;
+
+    /// Map with time and track id of detected photons
+    std::map<G4double, G4int> phot_;
+  };
+
+} // namespace nexus
+
+
+typedef G4THitsCollection<nexus::PetSensorHit> PetSensorHitsCollection;
+extern G4Allocator<nexus::PetSensorHit> PetSensorHitAllocator;
+
+
+// INLINE DEFINITIONS ////////////////////////////////////////////////
+
+namespace nexus {
+
+  inline void* PetSensorHit::operator new(size_t)
+  { return ((void*) PetSensorHitAllocator.MallocSingle()); }
+
+  inline void PetSensorHit::operator delete(void* hit)
+  { PetSensorHitAllocator.FreeSingle((PetSensorHit*) hit); }
+
+  inline G4int PetSensorHit::GetSnsID() const { return sns_id_; }
+  inline void PetSensorHit::SetSnsID(G4int id) { sns_id_ = id; }
+
+  inline G4double PetSensorHit::GetBinSize() const { return bin_size_; }
+
+  inline G4ThreeVector PetSensorHit::GetPosition() const { return position_; }
+  inline void PetSensorHit::SetPosition(const G4ThreeVector& p) { position_ = p; }
+
+  inline const std::map<G4double, G4int>& PetSensorHit::GetHistogram() const
+  { return histogram_; }
+
+  inline const std::map<G4double, G4int>& PetSensorHit::GetPhotonMap() const
+  { return phot_; }
+
+} // namespace nexus
+
+#endif

--- a/source/sensdet/PetSensorHit.h
+++ b/source/sensdet/PetSensorHit.h
@@ -21,7 +21,7 @@ public:
   /// Default constructor
   PetSensorHit();
   /// Constructor providing the detector ID and position
-  PetSensorHit(G4int ID, const G4ThreeVector& position, G4double bin_size);
+  PetSensorHit(G4int ID, const G4ThreeVector& position);
   /// Copy-constructor
   PetSensorHit(const PetSensorHit&);
   /// Destructor
@@ -47,26 +47,18 @@ public:
   /// Sets the position of the detector
   void SetPosition(const G4ThreeVector&);
 
-  /// Returns the bin size of the histogram
-  G4double GetBinSize() const;
-  /// Sets the bin size of the histogram. This can only be done
-  /// while the histogram is empty (rebinning is not supported).
-  void SetBinSize(G4double);
-
-  /// Adds counts to a given time bin
-  void Fill(G4double time, G4int counts=1);
+  /// Add detected photon
   void AddPhoton(G4double time, G4int track_id);
 
-  const std::map<G4double, G4int>& GetHistogram() const;
+  G4int GetDetPhotons() const;
   const std::map<G4double, G4int>& GetPhotonMap() const;
+
+  /// Number of detected photons
+  G4int counts_;
 
 private:
   G4int sns_id_;           ///< Detector ID number
-  G4double bin_size_;      ///< Size of time bin
   G4ThreeVector position_; ///< Detector position
-
-  /// Sparse histogram with number of photons detected per time bin
-  std::map<G4double, G4int> histogram_;
 
   /// Map with time and track id of detected photons
   std::map<G4double, G4int> phot_;
@@ -88,14 +80,11 @@ inline void PetSensorHit::operator delete(void* hit)
 inline G4int PetSensorHit::GetSnsID() const { return sns_id_; }
 inline void PetSensorHit::SetSnsID(G4int id) { sns_id_ = id; }
 
-inline G4double PetSensorHit::GetBinSize() const { return bin_size_; }
-
 inline G4ThreeVector PetSensorHit::GetPosition() const { return position_; }
 inline void PetSensorHit::SetPosition(const G4ThreeVector& p) { position_ = p; }
 
-inline const std::map<G4double, G4int>& PetSensorHit::GetHistogram() const
-{ return histogram_; }
-
+inline G4int PetSensorHit::GetDetPhotons() const
+{ return counts_; }
 inline const std::map<G4double, G4int>& PetSensorHit::GetPhotonMap() const
 { return phot_; }
 

--- a/source/sensdet/PetSensorHit.h
+++ b/source/sensdet/PetSensorHit.h
@@ -15,96 +15,88 @@
 #include <G4ThreeVector.hh>
 
 
-namespace nexus {
+class PetSensorHit: public G4VHit
+{
+public:
+  /// Default constructor
+  PetSensorHit();
+  /// Constructor providing the detector ID and position
+  PetSensorHit(G4int ID, const G4ThreeVector& position, G4double bin_size);
+  /// Copy-constructor
+  PetSensorHit(const PetSensorHit&);
+  /// Destructor
+  ~PetSensorHit();
 
-  class PetSensorHit: public G4VHit
-  {
-  public:
-    /// Default constructor
-    PetSensorHit();
-    /// Constructor providing the detector ID and position
-    PetSensorHit(G4int ID, const G4ThreeVector& position, G4double bin_size);
-    /// Copy-constructor
-    PetSensorHit(const PetSensorHit&);
-    /// Destructor
-    ~PetSensorHit();
+  /// Assignement operator
+  const PetSensorHit& operator=(const PetSensorHit&);
+  /// Equality operator
+  G4int operator==(const PetSensorHit&) const;
 
-    /// Assignement operator
-    const PetSensorHit& operator=(const PetSensorHit&);
-    /// Equality operator
-    G4int operator==(const PetSensorHit&) const;
+  /// Memory allocation
+  void* operator new(size_t);
+  /// Memory deallocation
+  void operator delete(void*);
 
-    /// Memory allocation
-    void* operator new(size_t);
-    /// Memory deallocation
-     void operator delete(void*);
+  /// Returns the detector ID code
+  G4int GetSnsID() const;
+  /// Sets the detector ID code
+  void  SetSnsID(G4int);
 
-    /// Returns the detector ID code
-    G4int GetSnsID() const;
-    /// Sets the detector ID code
-    void  SetSnsID(G4int);
+  /// Returns the position of the detector
+  G4ThreeVector GetPosition() const;
+  /// Sets the position of the detector
+  void SetPosition(const G4ThreeVector&);
 
-    /// Returns the position of the detector
-    G4ThreeVector GetPosition() const;
-    /// Sets the position of the detector
-    void SetPosition(const G4ThreeVector&);
+  /// Returns the bin size of the histogram
+  G4double GetBinSize() const;
+  /// Sets the bin size of the histogram. This can only be done
+  /// while the histogram is empty (rebinning is not supported).
+  void SetBinSize(G4double);
 
-    /// Returns the bin size of the histogram
-    G4double GetBinSize() const;
-    /// Sets the bin size of the histogram. This can only be done
-    /// while the histogram is empty (rebinning is not supported).
-    void SetBinSize(G4double);
+  /// Adds counts to a given time bin
+  void Fill(G4double time, G4int counts=1);
+  void AddPhoton(G4double time, G4int track_id);
 
-    /// Adds counts to a given time bin
-    void Fill(G4double time, G4int counts=1);
-    void AddPhoton(G4double time, G4int track_id);
+  const std::map<G4double, G4int>& GetHistogram() const;
+  const std::map<G4double, G4int>& GetPhotonMap() const;
 
-    const std::map<G4double, G4int>& GetHistogram() const;
-    const std::map<G4double, G4int>& GetPhotonMap() const;
+private:
+  G4int sns_id_;           ///< Detector ID number
+  G4double bin_size_;      ///< Size of time bin
+  G4ThreeVector position_; ///< Detector position
 
-  private:
-    G4int sns_id_;           ///< Detector ID number
-    G4double bin_size_;      ///< Size of time bin
-    G4ThreeVector position_; ///< Detector position
+  /// Sparse histogram with number of photons detected per time bin
+  std::map<G4double, G4int> histogram_;
 
-    /// Sparse histogram with number of photons detected per time bin
-    std::map<G4double, G4int> histogram_;
-
-    /// Map with time and track id of detected photons
-    std::map<G4double, G4int> phot_;
-  };
-
-} // namespace nexus
+  /// Map with time and track id of detected photons
+  std::map<G4double, G4int> phot_;
+};
 
 
-typedef G4THitsCollection<nexus::PetSensorHit> PetSensorHitsCollection;
-extern G4Allocator<nexus::PetSensorHit> PetSensorHitAllocator;
+typedef G4THitsCollection<PetSensorHit> PetSensorHitsCollection;
+extern G4Allocator<PetSensorHit> PetSensorHitAllocator;
 
 
 // INLINE DEFINITIONS ////////////////////////////////////////////////
 
-namespace nexus {
+inline void* PetSensorHit::operator new(size_t)
+{ return ((void*) PetSensorHitAllocator.MallocSingle()); }
 
-  inline void* PetSensorHit::operator new(size_t)
-  { return ((void*) PetSensorHitAllocator.MallocSingle()); }
+inline void PetSensorHit::operator delete(void* hit)
+{ PetSensorHitAllocator.FreeSingle((PetSensorHit*) hit); }
 
-  inline void PetSensorHit::operator delete(void* hit)
-  { PetSensorHitAllocator.FreeSingle((PetSensorHit*) hit); }
+inline G4int PetSensorHit::GetSnsID() const { return sns_id_; }
+inline void PetSensorHit::SetSnsID(G4int id) { sns_id_ = id; }
 
-  inline G4int PetSensorHit::GetSnsID() const { return sns_id_; }
-  inline void PetSensorHit::SetSnsID(G4int id) { sns_id_ = id; }
+inline G4double PetSensorHit::GetBinSize() const { return bin_size_; }
 
-  inline G4double PetSensorHit::GetBinSize() const { return bin_size_; }
+inline G4ThreeVector PetSensorHit::GetPosition() const { return position_; }
+inline void PetSensorHit::SetPosition(const G4ThreeVector& p) { position_ = p; }
 
-  inline G4ThreeVector PetSensorHit::GetPosition() const { return position_; }
-  inline void PetSensorHit::SetPosition(const G4ThreeVector& p) { position_ = p; }
+inline const std::map<G4double, G4int>& PetSensorHit::GetHistogram() const
+{ return histogram_; }
 
-  inline const std::map<G4double, G4int>& PetSensorHit::GetHistogram() const
-  { return histogram_; }
-
-  inline const std::map<G4double, G4int>& PetSensorHit::GetPhotonMap() const
-  { return phot_; }
-
-} // namespace nexus
+inline const std::map<G4double, G4int>& PetSensorHit::GetPhotonMap() const
+{ return phot_; }
 
 #endif

--- a/source/sensdet/ToFSD.cc
+++ b/source/sensdet/ToFSD.cc
@@ -2,10 +2,9 @@
 // petalosim | ToFSD.cc
 //
 // This class is the sensitive detector used for PETALO.
-// Each time a photoelectron is detected by a sensor, two PetSensorHit instances
-// are created (if needed): one to store the full response with large time
-// binning and the other one with a fine time binning, which stores only
-// the first part of the waveform.
+// The first time a photoelectron is detected by a particular sensor,
+// a PetSensorHit instance is created with two tasks:
+// storing the total charge response and the times of the individual photons.
 //
 // The PETALO Collaboration
 // ----------------------------------------------------------------------------
@@ -80,8 +79,8 @@ G4bool ToFSD::ProcessHits(G4Step *step, G4TouchableHistory *)
       HC_->insert(hit);
     }
 
+  hit->counts_ += 1;
   G4double time = step->GetPostStepPoint()->GetGlobalTime();
-  hit->Fill(time);
   hit->AddPhoton(time, step->GetTrack()->GetTrackID());
 
   return true;

--- a/source/sensdet/ToFSD.h
+++ b/source/sensdet/ToFSD.h
@@ -13,8 +13,8 @@
 #ifndef TOF_SD_H
 #define TOF_SD_H
 
+#include "PetSensorHit.h"
 #include <G4VSensitiveDetector.hh>
-#include "nexus/SensorHit.h"
 
 class G4Step;
 class G4HCofThisEvent;
@@ -86,7 +86,7 @@ private:
 
   G4int box_geom_; ///< Boolean required to change the naming_order_ for the case of the BoxSetup
 
-  SensorHitsCollection *HC_; ///< Pointer to the collection of hits
+  PetSensorHitsCollection *HC_; ///< Pointer to the collection of hits
 };
 
 // INLINE METHODS //////////////////////////////////////////////////

--- a/source/sensdet/ToFSD.h
+++ b/source/sensdet/ToFSD.h
@@ -22,8 +22,6 @@ class G4VTouchable;
 class G4TouchableHistory;
 class G4OpBoundaryProcess;
 
-using namespace nexus;
-
 class ToFSD : public G4VSensitiveDetector
 {
 public:

--- a/source/sensdet/ToFSD.h
+++ b/source/sensdet/ToFSD.h
@@ -2,10 +2,9 @@
 // petalosim | ToFSD.h
 //
 // This class is the sensitive detector used for PETALO.
-// Each time a photoelectron is detected by a sensor, two SensorHit instances
-// are created (if needed): one to store the full response with large time
-// binning and the other one with a fine time binning, which stores only
-// the first part of the waveform.
+// The first time a photoelectron is detected by a particular sensor,
+// a PetSensorHit instance is created with two tasks:
+// storing the total charge response and the times of the individual photons.
 //
 // The PETALO Collaboration
 // ----------------------------------------------------------------------------
@@ -57,11 +56,6 @@ public:
   /// Return the depth of the SD's grandmother volume in the geometry hierarchy
   G4int GetGrandMotherVolumeDepth() const;
 
-  /// Return the time binning chosen for the pmt hits
-  G4double GetTimeBinning() const;
-  /// Set a time binning for the pmt hits
-  void SetTimeBinning(G4double);
-
   /// Set the box geometry parameter
   void SetBoxGeom(G4int);
 
@@ -79,8 +73,6 @@ private:
   G4int sensor_depth_;      ///< Depth of the SD in the geometry tree
   G4int mother_depth_;      ///< Depth of the SD's mother in the geometry tree
   G4int grandmother_depth_; ///< Depth of the SD's grandmother in the geometry tree
-
-  G4double timebinning_; ///< Time bin width for TOF table
 
   G4int box_geom_; ///< Boolean required to change the naming_order_ for the case of the BoxSetup
 
@@ -100,9 +92,6 @@ inline G4int ToFSD::GetDetectorNamingOrder() const { return naming_order_; }
 
 inline void ToFSD::SetGrandMotherVolumeDepth(G4int d) { grandmother_depth_ = d; }
 inline G4int ToFSD::GetGrandMotherVolumeDepth() const { return grandmother_depth_; }
-
-inline G4double ToFSD::GetTimeBinning() const { return timebinning_; }
-inline void ToFSD::SetTimeBinning(G4double tb) { timebinning_ = tb; }
 
 inline void ToFSD::SetBoxGeom(G4int bg) { box_geom_ = bg; }
 

--- a/tests/pytest/persistency_test.py
+++ b/tests/pytest/persistency_test.py
@@ -71,8 +71,8 @@ def test_hdf5_structure(petalosim_files):
 
          assert 'event_id'  in tscolumns
          assert 'sensor_id' in tscolumns
-         assert 'time_bin'  in tscolumns
-         assert 'charge'    in tscolumns
+         assert 'time'  in tscolumns
+         assert 'track_id'    in tscolumns
 
 
          sposcolumns = h5out.root.MC.sns_positions.colnames
@@ -117,12 +117,3 @@ def test_primary_always_exists(petalosim_files):
      primary   = particles.primary.unique()
 
      assert 1 in primary
-
-
-def test_sensor_binning_is_saved(petalosim_files):
-     """Check that the sensor binning is saved in the configuration table."""
-     filename = petalosim_files
-     conf = pd.read_hdf(filename, 'MC/configuration')
-     parameters = conf.param_key.values
-
-     assert any('tof_bin_size' in p for p in parameters)

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -51,7 +51,6 @@ def test_create_petalo_output_file_full_body(config_tmpdir, output_tmpdir, PETAL
 
 /Geometry/SiPMpet/efficiency 0.2
 /Geometry/SiPMpet/visibility true
-/Geometry/SiPMpet/time_binning 5. picosecond
 /Geometry/SiPMpet/size 6. mm
 
 /Generator/Back2back/region AD_HOC
@@ -119,7 +118,6 @@ def test_create_petalo_output_file_ring_tiles(config_tmpdir, output_tmpdir, PETA
 
 /Geometry/SiPMpet/efficiency 0.2
 /Geometry/SiPMpet/visibility true
-/Geometry/SiPMpet/time_binning 5. picosecond
 /Geometry/SiPMpet/size 3. mm
 
 /Generator/Back2back/region CENTER
@@ -187,7 +185,6 @@ def test_create_petalo_output_file_pet_box_all_tiles(config_tmpdir, output_tmpdi
 /Geometry/PetBox/tile_type_c {tile_type2}
 /Geometry/PetBox/single_tile_coinc_plane 0
 /Geometry/PetBox/tile_refl 0.
-/Geometry/PetBox/sipm_time_binning 5. picosecond
 /Geometry/PetBox/sipm_pde 0.5
 
 /Generator/IonGenerator/region SOURCE
@@ -262,7 +259,6 @@ def test_create_petalo_output_file_nest(config_tmpdir, output_tmpdir, PETALODIR,
 
 /Geometry/SiPMpet/efficiency 0.2
 /Geometry/SiPMpet/visibility true
-/Geometry/SiPMpet/time_binning 5. picosecond
 /Geometry/SiPMpet/size 6. mm
 
 /Generator/Back2back/region AD_HOC
@@ -334,7 +330,6 @@ def test_create_petalo_output_file_phantom(config_tmpdir, output_tmpdir, PETALOD
 
 /Geometry/SiPMpet/efficiency 0.2
 /Geometry/SiPMpet/visibility true
-/Geometry/SiPMpet/time_binning 5. picosecond
 /Geometry/SiPMpet/size 6. mm
 
 /Generator/Back2back/region JPHANTOM


### PR DESCRIPTION
This PR modifies the output table with information useful for time-of-flight.  
The times of the individual photons are now saved, since there is almost no difference in the size of the table.  
Moreover, the ID of the optical photons that are detected are saved, which can be useful in some studies.