### PR TITLE
Configurable persistency manager

### DIFF
--- a/macros/PET_full_body.config.mac
+++ b/macros/PET_full_body.config.mac
@@ -35,4 +35,4 @@
 /petalosim/persistency/start_id 0
 /petalosim/persistency/sns_only false
 /petalosim/persistency/tof_time 50. nanosecond
-/petalosim/persistency/outputFile full_body.pet
+/petalosim/persistency/output_file full_body.pet

--- a/macros/PET_full_body_analysis.config.mac
+++ b/macros/PET_full_body_analysis.config.mac
@@ -31,4 +31,4 @@
 /petalosim/persistency/start_id 0
 /petalosim/persistency/sns_only false
 /petalosim/persistency/tof_time 50. nanosecond
-/petalosim/persistency/outputFile full_body.pet
+/petalosim/persistency/output_file full_body.pet

--- a/macros/PET_full_body_nest.config.mac
+++ b/macros/PET_full_body_nest.config.mac
@@ -42,4 +42,4 @@
 /petalosim/persistency/start_id 0
 /petalosim/persistency/sns_only false
 /petalosim/persistency/tof_time 5. nanosecond
-/petalosim/persistency/outputFile full_body_nest
+/petalosim/persistency/output_file full_body_nest

--- a/macros/PET_full_body_nest_phantom.config.mac
+++ b/macros/PET_full_body_nest_phantom.config.mac
@@ -36,4 +36,4 @@
 /petalosim/persistency/start_id 0
 /petalosim/persistency/sns_only false
 /petalosim/persistency/tof_time 5. nanosecond
-/petalosim/persistency/outputFile full_body_nest_phantom
+/petalosim/persistency/output_file full_body_nest_phantom

--- a/macros/PET_full_body_sens.config.mac
+++ b/macros/PET_full_body_sens.config.mac
@@ -36,4 +36,4 @@
 ### OUTPUT FILE
 
 /petalosim/persistency/start_id 0
-/petalosim/persistency/outputFile full_body_sens.pet
+/petalosim/persistency/output_file full_body_sens.pet

--- a/macros/PET_steps.config.mac
+++ b/macros/PET_steps.config.mac
@@ -36,4 +36,4 @@
 /petalosim/persistency/start_id 0
 /petalosim/persistency/sns_only false
 /petalosim/persistency/tof_time 50. nanosecond
-/petalosim/persistency/outputFile steps.pet
+/petalosim/persistency/output_file steps.pet

--- a/macros/PETit_ring.config.mac
+++ b/macros/PETit_ring.config.mac
@@ -35,4 +35,4 @@
 /petalosim/persistency/start_id 10
 /petalosim/persistency/sns_only false
 /petalosim/persistency/tof_time 50. nanosecond
-/petalosim/persistency/outputFile petit_ring.pet
+/petalosim/persistency/output_file petit_ring.pet

--- a/macros/PETit_ring_lutable.config.mac
+++ b/macros/PETit_ring_lutable.config.mac
@@ -29,4 +29,4 @@
 
 ### OUTPUT FILE
 /petalosim/persistency/start_id 10
-/petalosim/persistency/outputFile full_ring_lut.pet
+/petalosim/persistency/output_file full_ring_lut.pet

--- a/macros/PETit_tiles.config.mac
+++ b/macros/PETit_tiles.config.mac
@@ -27,4 +27,4 @@
 
 ### OUTPUT FILE
 /petalosim/persistency/start_id 10
-/petalosim/persistency/outputFile full_ring_3cm.next
+/petalosim/persistency/output_file full_ring_3cm.next

--- a/macros/PetBox.config.mac
+++ b/macros/PetBox.config.mac
@@ -36,5 +36,5 @@
 
 ### OUTPUT FILE
 /petalosim/persistency/start_id 0
-/petalosim/persistency/outputFile petbox.pet
+/petalosim/persistency/output_file petbox.pet
 

--- a/macros/PetBox_nest.config.mac
+++ b/macros/PetBox_nest.config.mac
@@ -38,4 +38,4 @@
 
 ### OUTPUT FILE
 /petalosim/persistency/start_id 0
-/petalosim/persistency/outputFile petbox_nest.pet
+/petalosim/persistency/output_file petbox_nest.pet

--- a/source/materials/PetOpticalMaterialProperties.cc
+++ b/source/materials/PetOpticalMaterialProperties.cc
@@ -379,7 +379,7 @@ G4MaterialPropertiesTable* TPB(G4double decay_time)
                                h_Planck * c_light / (250. * nm),  h_Planck * c_light / (230. * nm),
                                h_Planck * c_light / (210. * nm),  h_Planck * c_light / (190. * nm),
                                h_Planck * c_light / (170. * nm),  h_Planck * c_light / (150. * nm),
-                               h_Planck * c_light / (100. * nm),  opticalprops::optPhotMaxE_};
+                               opticalprops::optPhotMaxE_};
 
   std::vector<G4double> WLS_absLength = {
                               opticalprops::noAbsLength_,
@@ -390,7 +390,7 @@ G4MaterialPropertiesTable* TPB(G4double decay_time)
                               400. * nm,     400. * nm,     // 250 , 230 nm
                               350. * nm,     250. * nm,     // 210 , 190 nm
                               350. * nm,     400. * nm,     // 170 , 150 nm
-                              400. * nm,     opticalprops::noAbsLength_ };// 100 nm
+                              400. * nm};// ~108 nm
   mpt->AddProperty("WLSABSLENGTH", WLS_abs_energy, WLS_absLength);
 
   // WLS EMISSION SPECTRUM

--- a/source/persistency/PetaloPersistencyManager.cc
+++ b/source/persistency/PetaloPersistencyManager.cc
@@ -43,15 +43,16 @@ using namespace CLHEP;
 REGISTER_CLASS(PetaloPersistencyManager, PersistencyManagerBase)
 
 PetaloPersistencyManager::PetaloPersistencyManager():
-  PersistencyManagerBase(), msg_(0), ready_(false), store_evt_(true),
-  store_steps_(false), interacting_evt_(false), save_int_e_numb_(false),
+  PersistencyManagerBase(), msg_(0), output_file_("petalo_out"),
+  store_evt_(true), store_steps_(false),
+  interacting_evt_(false), save_int_e_numb_(false),
   efield_(0), event_type_("other"),
   saved_evts_(0), interacting_evts_(0), nevt_(0), start_id_(0), first_evt_(true),
   thr_charge_(0), tof_time_(50.*nanosecond), sns_only_(false),
   save_tot_charge_(true), h5writer_(0)
 {
   msg_ = new G4GenericMessenger(this, "/petalosim/persistency/");
-  msg_->DeclareMethod("outputFile", &PetaloPersistencyManager::OpenFile, "");
+  msg_->DeclareProperty("output_file", output_file_, "Path of output file.");
   msg_->DeclareProperty("eventType", event_type_,
                         "Type of event: bb0nu, bb2nu or background.");
   msg_->DeclareProperty("start_id", start_id_,
@@ -82,10 +83,10 @@ PetaloPersistencyManager::~PetaloPersistencyManager()
 
 
 
-void PetaloPersistencyManager::OpenFile(G4String filename)
+void PetaloPersistencyManager::OpenFile()
 {
   h5writer_ = new HDF5Writer();
-  G4String hdf5file = filename + ".h5";
+  G4String hdf5file = output_file_ + ".h5";
   h5writer_->Open(hdf5file, store_steps_);
   return;
 }

--- a/source/persistency/PetaloPersistencyManager.h
+++ b/source/persistency/PetaloPersistencyManager.h
@@ -49,7 +49,7 @@ public:
   virtual G4bool Retrieve(G4VPhysicalVolume *&);
 
 public:
-  void OpenFile(G4String);
+  void OpenFile();
   void CloseFile();
 
 private:
@@ -64,10 +64,10 @@ private:
 
 private:
   G4GenericMessenger *msg_; ///< User configuration messenger
+  G4String output_file_; ///< Output file name
 
   std::vector<G4String> secondary_macros_;
 
-  G4bool ready_;           ///< Is the PetaloPersistencyManager ready to go?
   G4bool store_evt_;       ///< Should we store the current event?
   G4bool store_steps_;     ///< Should we store the steps for the current event?
   G4bool interacting_evt_; ///< Has the current event interacted in ACTIVE?

--- a/source/petalo.cc
+++ b/source/petalo.cc
@@ -121,8 +121,6 @@ G4int main(int argc, char** argv)
   else {
     app->BeamOn(nevents);
   }
-  G4cout << "Here 0" << G4endl;
   delete app;
-  G4cout << "Here 1" << G4endl;
   return EXIT_SUCCESS;
 }

--- a/source/petalo.cc
+++ b/source/petalo.cc
@@ -121,7 +121,8 @@ G4int main(int argc, char** argv)
   else {
     app->BeamOn(nevents);
   }
-
+  G4cout << "Here 0" << G4endl;
   delete app;
+  G4cout << "Here 1" << G4endl;
   return EXIT_SUCCESS;
 }

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -57,7 +57,7 @@ def test_create_petalo_output_file_full_body(config_tmpdir, output_tmpdir, PETAL
 
 /process/optical/processActivation Cerenkov false
 
-/petalosim/persistency/outputFile {output_tmpdir}/{base_name_full_body}
+/petalosim/persistency/output_file {output_tmpdir}/{base_name_full_body}
 /nexus/random_seed 16062020
 
 """
@@ -124,7 +124,7 @@ def test_create_petalo_output_file_ring_tiles(config_tmpdir, output_tmpdir, PETA
 
 /process/optical/processActivation Cerenkov false
 
-/petalosim/persistency/outputFile {output_tmpdir}/{base_name_ring_tiles}
+/petalosim/persistency/output_file {output_tmpdir}/{base_name_ring_tiles}
 /nexus/random_seed 16062020
 
 """
@@ -195,7 +195,7 @@ def test_create_petalo_output_file_pet_box_all_tiles(config_tmpdir, output_tmpdi
 
 /process/optical/processActivation Cerenkov false
 
-/petalosim/persistency/outputFile {output_tmpdir}/{base_name}
+/petalosim/persistency/output_file {output_tmpdir}/{base_name}
 
 /nexus/random_seed 23102022
 """
@@ -268,7 +268,7 @@ def test_create_petalo_output_file_nest(config_tmpdir, output_tmpdir, PETALODIR,
 
 /process/optical/processActivation Cerenkov false
 
-/petalosim/persistency/outputFile {output_tmpdir}/{base_name_nest}
+/petalosim/persistency/output_file {output_tmpdir}/{base_name_nest}
 /nexus/random_seed 16062020
 
 """
@@ -334,7 +334,7 @@ def test_create_petalo_output_file_phantom(config_tmpdir, output_tmpdir, PETALOD
 
 /Generator/Back2back/region JPHANTOM
 
-/petalosim/persistency/outputFile {output_tmpdir}/{base_name_phantom}
+/petalosim/persistency/output_file {output_tmpdir}/{base_name_phantom}
 /nexus/random_seed 16062020
 
 """


### PR DESCRIPTION
This PR adds the possibility of not specifying a persistency manager. It can be useful for tests in visual mode, or using verbose. 
It must be approved after the corresponding nexus code is approved.