### PR TITLE
Eliminate unused variable and wrong reference

### DIFF
--- a/source/materials/PetOpticalMaterialProperties.cc
+++ b/source/materials/PetOpticalMaterialProperties.cc
@@ -320,12 +320,12 @@ G4MaterialPropertiesTable* PTFE()
 {
   G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
 
-  // REFLECTIVITY IN LXE (from https://link.springer.com/content/pdf/10.1140/epjc/s10052-020-7800-6.pdf)
+  // REFLECTIVITY IN LXE
   std::vector<G4double> ENERGIES = {opticalprops::optPhotMinE_, opticalprops::optPhotMaxE_};
   std::vector<G4double> REFLECTIVITY = {0.98, 0.98};
   mpt->AddProperty("REFLECTIVITY", ENERGIES, REFLECTIVITY);
 
-  // REFLEXION BEHAVIOR
+  // REFLECTION BEHAVIOR
   // Specular reflection about the normal to a microfacet.
   // Such a vector is chosen according to a gaussian distribution with
   // sigma = SigmaAlhpa (in rad) and centered in the average normal.

--- a/source/persistency/PetaloPersistencyManager.cc
+++ b/source/persistency/PetaloPersistencyManager.cc
@@ -46,15 +46,13 @@ PetaloPersistencyManager::PetaloPersistencyManager():
   PersistencyManagerBase(), msg_(0), output_file_("petalo_out"),
   store_evt_(true), store_steps_(false),
   interacting_evt_(false), save_int_e_numb_(false),
-  efield_(0), event_type_("other"),
-  saved_evts_(0), interacting_evts_(0), nevt_(0), start_id_(0), first_evt_(true),
+  efield_(0), saved_evts_(0), interacting_evts_(0),
+  nevt_(0), start_id_(0), first_evt_(true),
   thr_charge_(0), tof_time_(50.*nanosecond), sns_only_(false),
   save_tot_charge_(true), h5writer_(0)
 {
   msg_ = new G4GenericMessenger(this, "/petalosim/persistency/");
   msg_->DeclareProperty("output_file", output_file_, "Path of output file.");
-  msg_->DeclareProperty("eventType", event_type_,
-                        "Type of event: bb0nu, bb2nu or background.");
   msg_->DeclareProperty("start_id", start_id_,
                         "Starting event ID for this job.");
   msg_->DeclareProperty("thr_charge", thr_charge_, "Threshold for the charge saved in file.");

--- a/source/persistency/PetaloPersistencyManager.h
+++ b/source/persistency/PetaloPersistencyManager.h
@@ -75,8 +75,6 @@ private:
 
   G4double efield_; ///< Value of the electric field used in NEST
 
-  G4String event_type_; ///< event type: bb0nu, bb2nu, background or not set
-
   std::vector<G4int> sns_posvec_;
   std::vector<G4int> charge_posvec_;
 


### PR DESCRIPTION
This PR eliminates commits on July 28 and 31, while keeping the Sept 8's one.
Those commits are to be eliminated because a fully revision of the geometry is being done in another branch.
