### PR TITLE
Add saturation

### DIFF
--- a/macros/PETit_sat.config.mac
+++ b/macros/PETit_sat.config.mac
@@ -1,0 +1,32 @@
+### GEOMETRY
+
+/Geometry/PETitFBK/tile_refl 0
+/Geometry/PETitFBK/sipm_pde 0.3
+
+/Geometry/PETitFBK/sipm_cells true
+
+### GENERATOR
+/Generator/IonGenerator/region SOURCE
+/Generator/IonGenerator/atomic_number 11
+/Generator/IonGenerator/mass_number 22
+
+### PHYSICS
+#/process/optical/processActivation Scintillation true
+#/process/optical/processActivation Cerenkov      true
+
+### VERBOSITIES
+/run/verbose 0
+/event/verbose 0
+/tracking/verbose 0
+
+/process/em/verbose 0
+
+/nexus/random_seed 132323
+
+### OUTPUT FILE
+/petalosim/persistency/sipm_cells true
+/petalosim/persistency/save_tot_charge false
+
+/petalosim/persistency/start_id 0
+/petalosim/persistency/output_file petit_sat
+

--- a/macros/PETit_sat.init.mac
+++ b/macros/PETit_sat.init.mac
@@ -1,0 +1,22 @@
+### PHYSICS
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4OpticalPhysics
+/PhysicsList/RegisterPhysics PetaloPhysics
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+### GEOMETRY
+/nexus/RegisterGeometry PETitFBK
+
+### GENERATOR
+/nexus/RegisterGenerator IonGenerator
+
+### ACTIONS
+/nexus/RegisterRunAction DefaultRunAction
+/nexus/RegisterEventAction PetaloEventAction
+/nexus/RegisterTrackingAction PetaloTrackingAction
+
+/nexus/RegisterPersistencyManager PetaloPersistencyManager
+
+/nexus/RegisterMacro macros/PETit_sat.config.mac

--- a/source/geometries/MicroCellFBK.cc
+++ b/source/geometries/MicroCellFBK.cc
@@ -31,7 +31,7 @@ MicroCellFBK::~MicroCellFBK()
 void MicroCellFBK::Construct()
 {
   G4double cell_size   = 35 * micrometer;
-  G4double cell_thickn = 10 * micrometer;
+  G4double cell_thickn = 300 * micrometer;
 
   SetDimensions(G4ThreeVector(cell_size, cell_size, cell_thickn));
 

--- a/source/geometries/MicroCellFBK.cc
+++ b/source/geometries/MicroCellFBK.cc
@@ -1,0 +1,99 @@
+// ----------------------------------------------------------------------------
+// petalosim | MicroCellFBK.cc
+//
+// Each one of the cells of an FBK VUV SiPM.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#include "MicroCellFBK.h"
+#include "ToFSD.h"
+
+#include <G4Box.hh>
+#include <G4NistManager.hh>
+#include <G4OpticalSurface.hh>
+#include <G4LogicalSkinSurface.hh>
+#include <G4SDManager.hh>
+#include <G4VisAttributes.hh>
+
+using namespace nexus;
+using namespace CLHEP;
+
+MicroCellFBK::MicroCellFBK() : MicroCellGeometryBase()
+{
+}
+
+
+MicroCellFBK::~MicroCellFBK()
+{
+}
+
+void MicroCellFBK::Construct()
+{
+  G4double cell_size   = 35 * micrometer;
+  G4double cell_thickn = 10 * micrometer;
+
+  SetDimensions(G4ThreeVector(cell_size, cell_size, cell_thickn));
+
+  G4Box* active_cell_solid =
+      new G4Box("PHOTODIODES", cell_size/2., cell_size/2., cell_thickn/2);
+
+  G4Material* silicon =
+    G4NistManager::Instance()->FindOrBuildMaterial("G4_Si");
+
+  G4LogicalVolume* active_cell_logic =
+    new G4LogicalVolume(active_cell_solid, silicon, "PHOTODIODES");
+
+  this->SetLogicalVolume(active_cell_logic);
+
+    const G4int entries = 12;
+
+  G4double energies[entries] = {1.5 * eV, 6.19919 * eV, 6.35814 * eV,
+                                6.52546 * eV, 6.70182 * eV, 6.88799 * eV,
+                                7.08479 * eV, 7.29316 * eV, 7.51417 * eV,
+                                7.74898 * eV, 7.99895 * eV, 8.26558 * eV};
+  G4double reflectivity[entries] = {0., 0., 0.,
+                                    0., 0., 0.,
+                                    0., 0., 0.,
+                                    0., 0., 0.};
+ 
+  G4double efficiency[entries] = {GetPDE(), GetPDE(), GetPDE(),
+                                  GetPDE(), GetPDE(), GetPDE(),
+                                  GetPDE(), GetPDE(), GetPDE(),
+                                  GetPDE(), GetPDE(), GetPDE()};
+
+
+  G4MaterialPropertiesTable* sipm_mt = new G4MaterialPropertiesTable();
+  sipm_mt->AddProperty("EFFICIENCY", energies, efficiency, entries);
+  sipm_mt->AddProperty("REFLECTIVITY", energies, reflectivity, entries);
+
+  G4OpticalSurface* sipm_opsurf =
+      new G4OpticalSurface("SIPM_OPSURF", unified, polished, dielectric_metal);
+  sipm_opsurf->SetMaterialPropertiesTable(sipm_mt);
+
+  new G4LogicalSkinSurface("SIPM_OPSURF", active_cell_logic, sipm_opsurf);
+
+  // SENSITIVE DETECTOR ////////////////////////////////////////////
+
+  G4String sdname = "/SIPM/SiPMFBKVUV";
+  G4SDManager* sdmgr = G4SDManager::GetSDMpointer();
+
+  if (!sdmgr->FindSensitiveDetector(sdname, false))
+  {
+    ToFSD* sipmsd = new ToFSD(sdname);
+
+    sipmsd->SetDetectorVolumeDepth(0);
+    sipmsd->SetMotherVolumeDepth(1);
+    sipmsd->SetGrandMotherVolumeDepth(2);
+    sipmsd->SetDetectorNamingOrder(100);
+    sipmsd->SetBoxConf(fbk);
+    sipmsd->SetSiPMCells(true);
+
+    G4SDManager::GetSDMpointer()->AddNewDetector(sipmsd);
+    active_cell_logic->SetSensitiveDetector(sipmsd);
+  }
+
+  G4VisAttributes cell_col = G4Colour::Yellow();
+  active_cell_logic->SetVisAttributes(cell_col);
+  
+}

--- a/source/geometries/MicroCellFBK.h
+++ b/source/geometries/MicroCellFBK.h
@@ -1,0 +1,31 @@
+// ----------------------------------------------------------------------------
+// petalosim | MicroCellFBKVUV.h
+//
+// Each one of the cells of an FBK VUV SiPM.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef MICROCELL_FBK_H
+#define MICROCELL_FBK_H
+
+#include "MicroCellGeometryBase.h"
+
+#include "nexus/GeometryBase.h"
+
+using namespace nexus;
+
+class MicroCellFBK : public MicroCellGeometryBase
+{
+public:
+  /// Constructor
+  MicroCellFBK();
+  /// Destructor
+  ~MicroCellFBK();
+  
+  void Construct();
+ 
+
+};
+
+#endif

--- a/source/geometries/MicroCellGeometryBase.h
+++ b/source/geometries/MicroCellGeometryBase.h
@@ -1,0 +1,43 @@
+// ----------------------------------------------------------------------------
+// petalosim | MicroCellGeometryBase.h
+//
+// This is an abstract base class for encapsulation of SiPM microcells.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef MICROCELL_BASE_H
+#define MICROCELL_BASE_H
+
+#include "nexus/GeometryBase.h"
+#include <G4ThreeVector.hh>
+
+using namespace nexus;
+
+class MicroCellGeometryBase : public GeometryBase
+{
+public:
+  /// Destructor
+  virtual ~MicroCellGeometryBase();
+
+  void SetPDE(G4double eff);
+  G4double GetPDE() const;
+
+protected:
+  /// Default constructor defined as protected so no instance of
+  /// this base class can be created.
+  MicroCellGeometryBase();
+
+private:
+  G4double sipm_pde_;
+};
+
+// Inline definitions //
+
+inline MicroCellGeometryBase::MicroCellGeometryBase() {}
+inline MicroCellGeometryBase::~MicroCellGeometryBase() {}
+
+inline void MicroCellGeometryBase::SetPDE(G4double eff) { sipm_pde_ = eff; }
+inline G4double MicroCellGeometryBase::GetPDE() const { return sipm_pde_; }
+
+#endif

--- a/source/geometries/MicroCellHmtsuVUV.cc
+++ b/source/geometries/MicroCellHmtsuVUV.cc
@@ -1,0 +1,147 @@
+// ----------------------------------------------------------------------------
+// petalosim | MicroCellHmtsuVUV.cc
+//
+// Each one of the cells of a Hamamatsu VUV SiPM.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#include "MicroCellHmtsuVUV.h"
+#include "ToFSD.h"
+
+#include <G4Box.hh>
+#include <G4NistManager.hh>
+#include <G4OpticalSurface.hh>
+#include <G4LogicalSkinSurface.hh>
+#include <G4SDManager.hh>
+#include <G4VisAttributes.hh>
+
+using namespace nexus;
+using namespace CLHEP;
+
+MicroCellHmtsuVUV::MicroCellHmtsuVUV() : MicroCellGeometryBase()
+{
+}
+
+
+MicroCellHmtsuVUV::~MicroCellHmtsuVUV()
+{
+}
+
+void MicroCellHmtsuVUV::Construct()
+{
+  G4double cell_size   = 75 * micrometer;
+  G4double cell_thickn = 10 * micrometer;
+
+  SetDimensions(G4ThreeVector(cell_size, cell_size, cell_thickn));
+
+  G4Box* active_cell_solid =
+      new G4Box("PHOTODIODES", cell_size/2., cell_size/2., cell_thickn/2);
+
+  G4Material* silicon =
+    G4NistManager::Instance()->FindOrBuildMaterial("G4_Si");
+
+  G4LogicalVolume* active_cell_logic =
+    new G4LogicalVolume(active_cell_solid, silicon, "PHOTODIODES");
+
+  this->SetLogicalVolume(active_cell_logic);
+
+    // SiPM efficiency set using the official Hamamatsu specs.
+  const G4int entries = 104;
+
+  G4double energies[entries] = {1.37760 * eV, 1.38104 * eV, 1.42124 * eV, 1.47165 * eV,
+                                1.53422 * eV, 1.57798 * eV, 1.61482 * eV, 1.66337 * eV,
+                                1.70787 * eV, 1.75853 * eV, 1.80050 * eV, 1.83230 * eV,
+                                1.85690 * eV, 1.88217 * eV, 1.89940 * eV, 1.91695 * eV,
+                                1.93482 * eV, 1.95304 * eV, 1.97159 * eV, 1.99051 * eV,
+                                2.00494 * eV, 2.02945 * eV, 2.05457 * eV, 2.11209 * eV,
+                                2.15318 * eV, 2.19301 * eV, 2.22535 * eV, 2.25253 * eV,
+                                2.28039 * eV, 2.31215 * eV, 2.35146 * eV, 2.39904 * eV,
+                                2.46312 * eV, 2.52303 * eV, 2.58592 * eV, 2.63518 * eV,
+                                2.72160 * eV, 2.78554 * eV, 2.85256 * eV, 2.91263 * eV,
+                                2.96465 * eV, 3.00763 * eV, 3.05749 * eV, 3.12660 * eV,
+                                3.18052 * eV, 3.24266 * eV, 3.28112 * eV, 3.32050 * eV,
+                                3.36084 * eV, 3.40916 * eV, 3.46611 * eV, 3.51753 * eV,
+                                3.56284 * eV, 3.62508 * eV, 3.67322 * eV, 3.76487 * eV,
+                                3.86121 * eV, 3.95317 * eV, 4.04961 * eV, 4.13023 * eV,
+                                4.13280 * eV, 4.32615 * eV, 4.40398 * eV, 4.47022 * eV,
+                                4.51876 * eV, 4.56837 * eV, 4.63451 * eV, 4.71860 * eV,
+                                4.97232 * eV, 5.06307 * eV, 5.15720 * eV, 5.20884 * eV,
+                                5.24826 * eV, 5.39105 * eV, 5.45465 * eV, 5.64711 * eV,
+                                5.68569 * eV, 5.79657 * eV, 5.95416 * eV, 6.07587 * eV,
+                                6.18423 * eV, 6.26807 * eV, 6.34452 * eV, 6.42286 * eV,
+                                6.65927 * eV, 6.74563 * eV, 6.85679 * eV, 6.96000 * eV,
+                                7.09046 * eV, 7.17605 * eV, 7.25108 * eV, 7.30198 * eV,
+                                7.39278 * eV, 7.45904 * eV, 7.48588 * eV, 7.52650 * eV,
+                                7.55382 * eV, 7.67929 * eV, 7.83840 * eV, 7.88295 * eV,
+                                8.03517 * eV, 8.12935 * eV, 8.25842 * eV, 8.34119 * eV};
+
+  G4double reflectivity[entries] = {0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                                    0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                                    0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                                    0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                                    0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                                    0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                                    0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                                    0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                                    0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                                    0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                                    0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                                    0., 0., 0., 0., 0.};
+
+  G4double efficiency[entries] = {0.     , 0.06129, 0.08068, 0.10494, 0.13758,
+                                  0.16277, 0.18236, 0.20754, 0.22405, 0.24672,
+                                  0.26208, 0.27843, 0.28963, 0.30082, 0.30735,
+                                  0.31567, 0.32492, 0.33629, 0.34745, 0.35578,
+                                  0.36228, 0.36984, 0.37113, 0.38757, 0.39475,
+                                  0.40529, 0.41164, 0.42094, 0.43047, 0.43514,
+                                  0.43794, 0.43861, 0.43875, 0.43743, 0.43504,
+                                  0.43047, 0.41648, 0.40249, 0.3885 , 0.37684,
+                                  0.36425, 0.35115, 0.3372 , 0.31618, 0.29761,
+                                  0.28030, 0.26559, 0.25256, 0.24605, 0.24839,
+                                  0.25605, 0.26258, 0.26652, 0.26817, 0.27097,
+                                  0.27393, 0.27068, 0.26631, 0.25978, 0.24912,
+                                  0.24910, 0.21058, 0.20050, 0.19805, 0.19677,
+                                  0.19792, 0.20604, 0.22089, 0.26290, 0.27849,
+                                  0.29454, 0.29912, 0.29750, 0.29233, 0.29011,
+                                  0.28528, 0.28448, 0.28719, 0.28719, 0.28438,
+                                  0.28420, 0.28386, 0.28732, 0.29307, 0.31518,
+                                  0.31967, 0.32558, 0.32794, 0.32929, 0.33150,
+                                  0.33448, 0.33375, 0.31970, 0.31370, 0.30989,
+                                  0.29676, 0.28548, 0.21963, 0.13575, 0.11150,
+                                  0.04841, 0.02487, 0.00916, 0.};
+
+  G4MaterialPropertiesTable* sipm_mt = new G4MaterialPropertiesTable();
+  sipm_mt->AddProperty("EFFICIENCY", energies, efficiency, entries);
+  sipm_mt->AddProperty("REFLECTIVITY", energies, reflectivity, entries);
+
+  G4OpticalSurface* sipm_opsurf =
+      new G4OpticalSurface("SIPM_OPSURF", unified, polished, dielectric_metal);
+  sipm_opsurf->SetMaterialPropertiesTable(sipm_mt);
+
+  new G4LogicalSkinSurface("SIPM_OPSURF", active_cell_logic, sipm_opsurf);
+
+  // SENSITIVE DETECTOR ////////////////////////////////////////////
+
+  G4String sdname = "/SIPM/SiPMHmtsuVUV";
+  G4SDManager* sdmgr = G4SDManager::GetSDMpointer();
+
+  if (!sdmgr->FindSensitiveDetector(sdname, false))
+  {
+    ToFSD* sipmsd = new ToFSD(sdname);
+
+    sipmsd->SetDetectorVolumeDepth(0);
+    sipmsd->SetMotherVolumeDepth(1);
+    sipmsd->SetGrandMotherVolumeDepth(2);
+    sipmsd->SetDetectorNamingOrder(0);
+    sipmsd->SetBoxConf(hama);
+    sipmsd->SetSiPMCells(true);
+
+    G4SDManager::GetSDMpointer()->AddNewDetector(sipmsd);
+    active_cell_logic->SetSensitiveDetector(sipmsd);
+  }
+
+  G4VisAttributes cell_col = G4Colour::Yellow();
+  active_cell_logic->SetVisAttributes(cell_col);
+  
+}

--- a/source/geometries/MicroCellHmtsuVUV.cc
+++ b/source/geometries/MicroCellHmtsuVUV.cc
@@ -31,7 +31,7 @@ MicroCellHmtsuVUV::~MicroCellHmtsuVUV()
 void MicroCellHmtsuVUV::Construct()
 {
   G4double cell_size   = 75 * micrometer;
-  G4double cell_thickn = 10 * micrometer;
+  G4double cell_thickn = 300 * micrometer;
 
   SetDimensions(G4ThreeVector(cell_size, cell_size, cell_thickn));
 

--- a/source/geometries/MicroCellHmtsuVUV.h
+++ b/source/geometries/MicroCellHmtsuVUV.h
@@ -1,0 +1,30 @@
+// ----------------------------------------------------------------------------
+// petalosim | MicroCellHmtsuVUV.h
+//
+// Each one of the cells of a Hamamatsu VUV SiPM.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef MICROCELL_HMTSU_H
+#define MICROCELL_HMTSU_H
+
+#include "MicroCellGeometryBase.h"
+
+#include "nexus/GeometryBase.h"
+
+using namespace nexus;
+
+class MicroCellHmtsuVUV : public MicroCellGeometryBase
+{
+ public:
+  /// Constructor
+  MicroCellHmtsuVUV();
+  /// Destructor
+  ~MicroCellHmtsuVUV();
+  
+  void Construct();
+
+};
+
+#endif

--- a/source/geometries/PETit.cc
+++ b/source/geometries/PETit.cc
@@ -40,13 +40,13 @@ PETit::PETit() : GeometryBase(),
                  box_vis_(0),
                  tile_vis_(1),
                  tile_refl_(0.),
-                 specific_vertex_{},
-                 max_step_size_(1. * mm),
-                 pressure_(1 * bar),
                  dist_dice_flange_(18.6 * mm),
                  n_tile_rows_(2),
                  n_tile_columns_(2),
-                 sipm_cells_(false)
+                 specific_vertex_{},
+                 sipm_cells_(false),
+                 max_step_size_(1. * mm),
+                 pressure_(1 * bar)
 
 {
   // Messenger

--- a/source/geometries/PETit.cc
+++ b/source/geometries/PETit.cc
@@ -45,7 +45,8 @@ PETit::PETit() : GeometryBase(),
                  pressure_(1 * bar),
                  dist_dice_flange_(18.6 * mm),
                  n_tile_rows_(2),
-                 n_tile_columns_(2)
+                 n_tile_columns_(2),
+                 sipm_cells_(false)
 
 {
   // Messenger
@@ -56,6 +57,8 @@ PETit::PETit() : GeometryBase(),
                         "Visibility of the basic structure");
   msg_->DeclareProperty("tile_vis", tile_vis_, "Visibility of tiles");
   msg_->DeclareProperty("tile_refl", tile_refl_, "Reflectivity of SiPM boards");
+  msg_->DeclareProperty("sipm_cells", sipm_cells_,
+                        "True if each cell of SiPMs is simulated");
 
   msg_->DeclarePropertyWithUnit("specific_vertex", "mm",  specific_vertex_,
                                 "Set generation vertex.");
@@ -152,6 +155,7 @@ void PETit::BuildSensors()
   tile.SetBoxConf(hama);
   tile.SetTileVisibility(tile_vis_);
   tile.SetTileReflectivity(tile_refl_);
+  tile.SetSiPMCells(sipm_cells_);
   tile.Construct();
 
   G4double tile_size_x = tile.GetDimensions().x();

--- a/source/geometries/PETit.h
+++ b/source/geometries/PETit.h
@@ -40,17 +40,14 @@ private:
   G4LogicalVolume* active_logic_;
 
   G4bool visibility_;
-  G4double reflectivity_;
   G4bool box_vis_, tile_vis_;
   G4double tile_refl_;
+  G4double dist_dice_flange_;
+  G4double n_tile_rows_, n_tile_columns_;
 
   G4ThreeVector specific_vertex_;
 
-  G4double n_tile_rows_, n_tile_columns_;
   G4bool sipm_cells_;
-  G4double tile_thickn_;
-  G4double dist_dice_flange_;
-
   G4double max_step_size_, pressure_;
 
   /// Messenger for the definition of control commands

--- a/source/geometries/PETit.h
+++ b/source/geometries/PETit.h
@@ -47,6 +47,7 @@ private:
   G4ThreeVector specific_vertex_;
 
   G4double n_tile_rows_, n_tile_columns_;
+  G4bool sipm_cells_;
   G4double tile_thickn_;
   G4double dist_dice_flange_;
 

--- a/source/geometries/PETitFBK.cc
+++ b/source/geometries/PETitFBK.cc
@@ -46,7 +46,8 @@ PETitFBK::PETitFBK() : GeometryBase(),
                        pressure_(1 * bar),
                        dist_dice_flange_(18.6 * mm),
                        n_tile_rows_(2),
-                       n_tile_columns_(2)
+                       n_tile_columns_(2),
+                       sipm_cells_(false)
 
 {
   // Messenger
@@ -59,6 +60,8 @@ PETitFBK::PETitFBK() : GeometryBase(),
   msg_->DeclareProperty("tile_refl", tile_refl_, "Reflectivity of SiPM boards");
   msg_->DeclareProperty("sipm_pde", sipm_pde_,
                         "SiPM photodetection efficiency");
+  msg_->DeclareProperty("sipm_cells", sipm_cells_,
+                        "True if each cell of SiPMs is simulated");
 
   msg_->DeclarePropertyWithUnit("specific_vertex", "mm",  specific_vertex_,
                                 "Set generation vertex.");
@@ -159,6 +162,7 @@ void PETitFBK::BuildSensors()
   tile.SetTileVisibility(tile_vis_);
   tile.SetTileReflectivity(tile_refl_);
   tile.SetPDE(sipm_pde_);
+  tile.SetSiPMCells(sipm_cells_);
   tile.Construct();
 
   G4double tile_size_x = tile.GetDimensions().x();

--- a/source/geometries/PETitFBK.cc
+++ b/source/geometries/PETitFBK.cc
@@ -41,13 +41,12 @@ PETitFBK::PETitFBK() : GeometryBase(),
                        tile_vis_(1),
                        tile_refl_(0.),
                        sipm_pde_(0.3),
-                       specific_vertex_{},
-                       max_step_size_(1. * mm),
-                       pressure_(1 * bar),
-                       dist_dice_flange_(18.6 * mm),
                        n_tile_rows_(2),
                        n_tile_columns_(2),
-                       sipm_cells_(false)
+                       sipm_cells_(false),
+                       specific_vertex_{},
+                       max_step_size_(1. * mm),
+                       pressure_(1 * bar)
 
 {
   // Messenger

--- a/source/geometries/PETitFBK.h
+++ b/source/geometries/PETitFBK.h
@@ -40,25 +40,21 @@ private:
   G4LogicalVolume* active_logic_;
 
   G4bool visibility_;
-  G4double reflectivity_;
   G4bool box_vis_, tile_vis_;
   G4double tile_refl_, sipm_pde_;
+  G4double n_tile_rows_, n_tile_columns_;
   G4bool sipm_cells_;
 
   G4ThreeVector specific_vertex_;
 
-  G4double n_tile_rows_, n_tile_columns_;
-  G4double tile_thickn_;
-  G4double dist_dice_flange_;
-
   G4double max_step_size_, pressure_;
+
+  G4double end_of_teflon_z_;
 
   /// Messenger for the definition of control commands
   G4GenericMessenger* msg_;
 
   PETitBox* box_;
-
-  G4double end_of_teflon_z_;
 };
 
 #endif

--- a/source/geometries/PETitFBK.h
+++ b/source/geometries/PETitFBK.h
@@ -43,6 +43,7 @@ private:
   G4double reflectivity_;
   G4bool box_vis_, tile_vis_;
   G4double tile_refl_, sipm_pde_;
+  G4bool sipm_cells_;
 
   G4ThreeVector specific_vertex_;
 

--- a/source/geometries/PETitPyrex.cc
+++ b/source/geometries/PETitPyrex.cc
@@ -156,6 +156,7 @@ void PETitPyrex::BuildBox()
   tile_->SetBoxConf(hama);
   tile_->SetTileVisibility(tile_vis_);
   tile_->SetTileReflectivity(tile_refl_);
+  tile_->SetSiPMCells(false);
 
   tile_->Construct();
   tile_thickn_ = tile_->GetDimensions().z();

--- a/source/geometries/PETitPyrex.cc
+++ b/source/geometries/PETitPyrex.cc
@@ -45,9 +45,6 @@ PETitPyrex::PETitPyrex() : GeometryBase(),
                            tile_refl_(0.),
                            panel_refl_(0.),
                            blue_tiles_(0),
-                           specific_vertex_{},
-                           max_step_size_(1. * mm),
-                           pressure_(1 * bar),
                            n_tile_rows_(2),
                            n_tile_columns_(2),
                            dist_lat_panels_(69. * mm),
@@ -66,7 +63,9 @@ PETitPyrex::PETitPyrex() : GeometryBase(),
                            dist_ham_blue_(19.35 * mm),
                            panel_sipm_xy_size_(66. * mm),
                            dist_sipms_panel_sipms_(0.3 * mm),
-                           wls_depth_(0.001 * mm)
+                           wls_depth_(0.001 * mm),
+                           specific_vertex_{},
+                           pressure_(1 * bar)
 
 {
   // Messenger
@@ -138,7 +137,6 @@ void PETitPyrex::BuildBox()
                     false, 0, false);
 
   active_logic_ = box_->GetActiveVolume();
-  G4double ih_z_size = box_->GetHatZSize();
 
   G4Box* entry_panel_solid =
     new G4Box("ENTRY_PANEL", entry_panel_x_size_/2., entry_panel_y_size_/2.,

--- a/source/geometries/PETitPyrex.h
+++ b/source/geometries/PETitPyrex.h
@@ -52,13 +52,9 @@ private:
   G4double tile_refl_, panel_refl_;
   G4bool blue_tiles_;
 
-  G4ThreeVector specific_vertex_;
-
   G4double n_tile_rows_, n_tile_columns_;
   G4double tile_thickn_;
   G4double dist_dice_flange_;
-
-  G4double max_step_size_, pressure_;
 
   G4double dist_lat_panels_;
 
@@ -75,6 +71,8 @@ private:
   G4double panel_sipm_xy_size_, dist_sipms_panel_sipms_;
   G4double wls_depth_;
 
+  G4ThreeVector specific_vertex_;
+  G4double pressure_;
 
   /// Messenger for the definition of control commands
   G4GenericMessenger* msg_;

--- a/source/geometries/PETitPyrexMix.cc
+++ b/source/geometries/PETitPyrexMix.cc
@@ -245,6 +245,7 @@ void PETitPyrexMix::BuildSensors()
   tile0.SetBoxConf(hama);
   tile0.SetTileVisibility(tile_vis_);
   tile0.SetTileReflectivity(tile_refl_);
+  tile0.SetSiPMCells(false);
 
   tile0.Construct();
 
@@ -277,6 +278,7 @@ void PETitPyrexMix::BuildSensors()
   tile2.SetBoxConf(hama); // we use hama because the IDs must be 111, 112, ... 118 etc.
   tile2.SetTileVisibility(tile_vis_);
   tile2.SetTileReflectivity(tile_refl_);
+  tile2.SetSiPMCells(false);
 
   tile2.Construct();
 

--- a/source/geometries/PETitPyrexMix.cc
+++ b/source/geometries/PETitPyrexMix.cc
@@ -47,9 +47,6 @@ PETitPyrexMix::PETitPyrexMix() : GeometryBase(),
                                  tile_vis_(1),
                                  tile_refl_(0.),
                                  panel_refl_(0.),
-                                 specific_vertex_{},
-                                 max_step_size_(1. * mm),
-                                 pressure_(1 * bar),
                                  n_tile_rows_(2),
                                  n_tile_columns_(2),
                                  dist_lat_panels_(69. * mm),
@@ -66,10 +63,9 @@ PETitPyrexMix::PETitPyrexMix() : GeometryBase(),
                                  v_l_panel_z_size_(46.7 * mm),
                                  dist_ham_vuv_(18.6 * mm),
                                  dist_fbk_(21.05 * mm),
-                                 panel_sipm_xy_size_(66. * mm),
-                                 dist_sipms_panel_sipms_(0.3 * mm),
-                                 wls_depth_(0.001 * mm),
-                                 sipm_pde_(0.3)
+                                 sipm_pde_(0.3),
+                                 specific_vertex_{},
+                                 pressure_(1 * bar)
 
 {
   // Messenger
@@ -138,7 +134,6 @@ void PETitPyrexMix::BuildBox()
                     false, 0, false);
 
   active_logic_ = box_->GetActiveVolume();
-  G4double ih_z_size = box_->GetHatZSize();
 
   G4Box* entry_panel_solid =
     new G4Box("ENTRY_PANEL", entry_panel_x_size_/2., entry_panel_y_size_/2., panel_thickness_/2.);

--- a/source/geometries/PETitPyrexMix.h
+++ b/source/geometries/PETitPyrexMix.h
@@ -47,13 +47,7 @@ private:
   G4bool box_vis_, tile_vis_;
   G4double tile_refl_, panel_refl_;
 
-  G4ThreeVector specific_vertex_;
-
   G4double n_tile_rows_, n_tile_columns_;
-  G4double tile_thickn_;
-  G4double dist_dice_flange_;
-
-  G4double max_step_size_, pressure_;
 
   G4double dist_lat_panels_;
 
@@ -67,9 +61,10 @@ private:
   G4double h_l_panel_z_size_, h_l_panel_y_pos_;
   G4double v_l_panel_z_size_;
   G4double dist_ham_vuv_, dist_fbk_;
-  G4double panel_sipm_xy_size_, dist_sipms_panel_sipms_;
-  G4double wls_depth_, sipm_pde_;
+  G4double sipm_pde_;
 
+  G4ThreeVector specific_vertex_;
+  G4double pressure_;
 
   /// Messenger for the definition of control commands
   G4GenericMessenger* msg_;

--- a/source/geometries/SiPMCells.cc
+++ b/source/geometries/SiPMCells.cc
@@ -41,12 +41,12 @@ void SiPMCells::Construct()
   // PACKAGE //
   G4ThreeVector sipm_dim = GetDim();
 
-  G4Box* sipm_solid = new G4Box("SiPMHmtsuVUV", sipm_dim.x()/2.,
+  G4Box* sipm_solid = new G4Box("SiPM", sipm_dim.x()/2.,
                                 sipm_dim.y()/2., sipm_dim.z()/2);
 
   G4Material* plastic = petmaterials::FR4();
   G4LogicalVolume* sipm_logic =
-      new G4LogicalVolume(sipm_solid, plastic, "SiPMHmtsuVUV");
+      new G4LogicalVolume(sipm_solid, plastic, "SiPM");
 
   this->SetLogicalVolume(sipm_logic);
 

--- a/source/geometries/SiPMCells.cc
+++ b/source/geometries/SiPMCells.cc
@@ -1,0 +1,86 @@
+// ----------------------------------------------------------------------------
+// petalosim | SiPMCell.cc
+//
+// Generic SiPM geometry with individual cells.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#include "SiPMCells.h"
+#include "PetMaterialsList.h"
+#include "MicroCellHmtsuVUV.h"
+#include "MicroCellFBK.h"
+
+#include "nexus/Visibilities.h"
+#include "nexus/IonizationSD.h"
+
+#include <G4Box.hh>
+#include <G4LogicalVolume.hh>
+#include <G4VisAttributes.hh>
+#include <G4PVPlacement.hh>
+#include <G4Material.hh>
+#include <G4PhysicalConstants.hh>
+
+#include <cassert>
+
+
+using namespace nexus;
+using namespace CLHEP;
+
+SiPMCells::SiPMCells() : GeometryBase()
+{
+}
+
+SiPMCells::~SiPMCells()
+{
+}
+
+void SiPMCells::Construct()
+{
+
+  // PACKAGE //
+  G4ThreeVector sipm_dim = GetDim();
+
+  G4Box* sipm_solid = new G4Box("SiPMHmtsuVUV", sipm_dim.x()/2.,
+                                sipm_dim.y()/2., sipm_dim.z()/2);
+
+  G4Material* plastic = petmaterials::FR4();
+  G4LogicalVolume* sipm_logic =
+      new G4LogicalVolume(sipm_solid, plastic, "SiPMHmtsuVUV");
+
+  this->SetLogicalVolume(sipm_logic);
+
+  if (pxl_name_ == "MicroCellHmtsuVUV") {
+    pxl_ = new MicroCellHmtsuVUV();
+    pxl_->Construct();
+  } else if (pxl_name_ == "MicroCellFBK") {
+    pxl_ = new MicroCellFBK();
+    pxl_->SetPDE(GetPDE());
+    pxl_->Construct();
+  } else {
+    G4Exception("[SiPMCells]", "Construct()", FatalException,
+                "Unknown type of microcell!");
+  }
+  G4LogicalVolume* pxl_logic = pxl_->GetLogicalVolume();
+  G4double pxl_depth = pxl_->GetDimensions().z();
+  
+  G4int n_rows    =  sipm_dim.x() / pitch_;
+  G4int n_columns =  sipm_dim.y() / pitch_;
+  assert(n_rows*n_columns == n_microcells_);
+
+  G4double x = 0;
+  G4double y = 0;
+
+  G4int copy_no = 0;
+
+  for (G4int i=0; i<n_rows; i++) {
+    for (G4int j=0; j<n_columns; j++) {
+      x = - sipm_dim.x()/2 + pitch_/2 + i*pitch_;
+      y = - sipm_dim.y()/2 + pitch_/2 + j*pitch_;
+      new G4PVPlacement(0, G4ThreeVector(x, y, sipm_dim.z()/2. - pxl_depth/2.),
+                        pxl_logic, "PHOTODIODES", sipm_logic,
+                        false, copy_no, false);
+      copy_no += 1;
+    }
+  }
+}

--- a/source/geometries/SiPMCells.h
+++ b/source/geometries/SiPMCells.h
@@ -1,0 +1,55 @@
+// ----------------------------------------------------------------------------
+// petalosim | SiPMCell.h
+//
+// Generic SiPM geometry with individual cells.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef SIPM_CELL_H
+#define SIPM_CELL_H
+
+#include "nexus/GeometryBase.h"
+
+using namespace nexus;
+
+class MicroCellGeometryBase;
+
+class SiPMCells : public GeometryBase
+{
+public:
+  /// Constructor
+  SiPMCells();
+  /// Destructor
+  ~SiPMCells();
+
+  /// Invoke this method to build the volumes of the geometry
+  void Construct();
+
+  void SetNumbOfMicroCells(G4int npxl);
+  void SetPitch(G4double pitch);
+  void SetMicroCell(G4String pxl_name);
+  void SetPDE(G4double pde);
+  G4double GetPDE() const;
+
+  void SetDim(G4ThreeVector dim);
+  G4ThreeVector GetDim() const;
+  
+private:
+  G4int n_microcells_;
+  G4double pitch_;
+  G4String pxl_name_;
+  MicroCellGeometryBase* pxl_;
+  G4ThreeVector dim_;
+  G4double sipm_pde_;
+};
+
+inline void SiPMCells::SetNumbOfMicroCells(G4int npxl) { n_microcells_ = npxl;}
+inline void SiPMCells::SetPitch(G4double pitch) { pitch_ = pitch;}
+inline void SiPMCells::SetMicroCell(G4String pxl) { pxl_name_ = pxl;}
+inline void SiPMCells::SetPDE(G4double pde) { sipm_pde_ = pde;}
+inline G4double SiPMCells::GetPDE() const { return sipm_pde_;}
+inline void SiPMCells::SetDim(G4ThreeVector dim) {dim_ = dim;}
+inline G4ThreeVector SiPMCells::GetDim() const {return dim_;}
+
+#endif

--- a/source/geometries/TileFBK.h
+++ b/source/geometries/TileFBK.h
@@ -14,7 +14,6 @@
 #include <G4ThreeVector.hh>
 
 class G4GenericMessenger;
-class SiPMFBKVUV;
 
 using namespace nexus;
 
@@ -46,8 +45,6 @@ using namespace nexus;
     G4int n_rows_, n_columns_;
 
     G4int sipm_naming_order_;
-
-    SiPMFBKVUV* sipm_;
 
   };
 

--- a/source/geometries/TileGeometryBase.h
+++ b/source/geometries/TileGeometryBase.h
@@ -35,6 +35,9 @@ public:
   void SetPDE(G4double eff);
   G4double GetPDE() const;
 
+  void SetSiPMCells(G4int cells);
+  G4int GetSiPMCells() const;
+
   void SetMotherPhysicalVolume(G4VPhysicalVolume *mpv);
   G4VPhysicalVolume *GetMotherPhysicalVolume() const;
 
@@ -50,6 +53,7 @@ private:
   G4bool tile_vis_;
   G4double tile_refl_;
   G4double sipm_pde_;
+  G4bool sipm_cells_;
 };
 
 // Inline definitions ///////////////////////////////////
@@ -68,6 +72,9 @@ inline G4double TileGeometryBase::GetTileReflectivity() const { return tile_refl
 
 inline void TileGeometryBase::SetPDE(G4double eff) { sipm_pde_ = eff; }
 inline G4double TileGeometryBase::GetPDE() const { return sipm_pde_; }
+
+inline void TileGeometryBase::SetSiPMCells(G4int cells) { sipm_cells_ = cells; }
+inline G4int TileGeometryBase::GetSiPMCells() const { return sipm_cells_; }
 
 inline void TileGeometryBase::SetMotherPhysicalVolume(G4VPhysicalVolume *mpv) { mpv_ = mpv; }
 inline G4VPhysicalVolume *TileGeometryBase::GetMotherPhysicalVolume() const { return mpv_; }

--- a/source/geometries/TileHamamatsuVUV.cc
+++ b/source/geometries/TileHamamatsuVUV.cc
@@ -81,7 +81,7 @@ void TileHamamatsuVUV::Construct()
     sipm_cells.SetPitch(0.075 * mm);
     sipm_cells.SetMicroCell("MicroCellHmtsuVUV");
     sipm_cells.Construct();
-    sipm_dim = sipm_cells.GetDimensions();
+    sipm_dim = sipm_cells.GetDim();
   } else {
     sipm.SetSensorDepth(1);
     sipm.SetMotherDepth(2);

--- a/source/geometries/TileHamamatsuVUV.h
+++ b/source/geometries/TileHamamatsuVUV.h
@@ -44,8 +44,6 @@ private:
   G4double lxe_thick_;
   G4double quartz_rindex_;
   G4double quartz_thick_;
-
-  SiPMHamamatsuVUV *sipm_;
 };
 
 #endif

--- a/source/persistency/PetaloPersistencyManager.cc
+++ b/source/persistency/PetaloPersistencyManager.cc
@@ -49,18 +49,24 @@ PetaloPersistencyManager::PetaloPersistencyManager():
   efield_(0), saved_evts_(0), interacting_evts_(0),
   nevt_(0), start_id_(0), first_evt_(true),
   thr_charge_(0), tof_time_(50.*nanosecond), sns_only_(false),
-  save_tot_charge_(true), h5writer_(0)
+  save_tot_charge_(true), sipm_cells_(false), h5writer_(0)
 {
   msg_ = new G4GenericMessenger(this, "/petalosim/persistency/");
   msg_->DeclareProperty("output_file", output_file_, "Path of output file.");
   msg_->DeclareProperty("start_id", start_id_,
                         "Starting event ID for this job.");
-  msg_->DeclareProperty("thr_charge", thr_charge_, "Threshold for the charge saved in file.");
-  msg_->DeclareProperty("sns_only", sns_only_, "If true, no true information is saved.");
-  msg_->DeclareProperty("save_tot_charge", save_tot_charge_, "If true, total charge is saved.");
+  msg_->DeclareProperty("thr_charge", thr_charge_,
+                        "Threshold for the charge saved in file.");
+  msg_->DeclareProperty("sns_only", sns_only_,
+                        "If true, no true information is saved.");
+  msg_->DeclareProperty("save_tot_charge", save_tot_charge_,
+                        "If true, total charge is saved.");
+  msg_->DeclareProperty("sipm_cells", sipm_cells_,
+                        "True if each individual cell of SiPMs is simulated.");
 
   G4GenericMessenger::Command& time_cmd =
-    msg_->DeclareProperty("tof_time", tof_time_, "Time saved in tof table per sensor");
+    msg_->DeclareProperty("tof_time", tof_time_,
+                          "Time saved in tof table per sensor");
   time_cmd.SetUnitCategory("Time");
   time_cmd.SetParameterName("tof_time", false);
   time_cmd.SetRange("tof_time>0.");
@@ -311,14 +317,21 @@ void PetaloPersistencyManager::StoreSensorHits(G4VHitsCollection* hc)
       const std::map<G4double, G4int>& phot = hit->GetPhotonMap();
       std::map<G4double, G4int>::const_iterator it;
       for (it = phot.begin(); it != phot.end(); ++it) {
-        if (it->first <= tof_time_){
-          h5writer_->WriteSensorTofInfo(nevt_, (unsigned int)s_id, (float)it->first,
+        if (sipm_cells_) {
+          h5writer_->WriteSensorTofInfo(nevt_, (unsigned int)s_id,
+                                        (float)it->first,
                                         (unsigned int)it->second);
-        }
-        else {
-          break;
-        }
+        } else {
+          if (it->first <= tof_time_){
+            h5writer_->WriteSensorTofInfo(nevt_, (unsigned int)s_id,
+                                          (float)it->first,
+                                          (unsigned int)it->second);
+          } else {
+            break;
+          }
+        }  
       }
+
     }
   }
 }

--- a/source/persistency/PetaloPersistencyManager.h
+++ b/source/persistency/PetaloPersistencyManager.h
@@ -90,6 +90,7 @@ private:
   G4double tof_time_;
   G4bool sns_only_;
   G4bool save_tot_charge_;
+  G4bool sipm_cells_;
   HDF5Writer *h5writer_; ///< Event writer to hdf5 file
 
   G4double bin_size_, tof_bin_size_, wire_bin_size_;

--- a/source/sensdet/ToFSD.cc
+++ b/source/sensdet/ToFSD.cc
@@ -48,7 +48,7 @@ void ToFSD::Initialize(G4HCofThisEvent* HCE)
   HCE->AddHitsCollection(HCID, HC_);
 }
 
-G4bool ToFSD::ProcessHits(G4Step *step, G4TouchableHistory *)
+G4bool ToFSD::ProcessHits(G4Step* step, G4TouchableHistory*)
 {
   // Check whether the track is an optical photon
   G4ParticleDefinition *pdef = step->GetTrack()->GetDefinition();
@@ -57,9 +57,9 @@ G4bool ToFSD::ProcessHits(G4Step *step, G4TouchableHistory *)
 
   const G4VTouchable *touchable =
     step->GetPostStepPoint()->GetTouchable();
-  
+
   G4int sns_id = FindID(touchable);
-  
+
   PetSensorHit* hit = 0;
   for (size_t i = 0; i < HC_->entries(); i++)
     {
@@ -69,7 +69,7 @@ G4bool ToFSD::ProcessHits(G4Step *step, G4TouchableHistory *)
           break;
         }
     }
-  
+
   // If no hit associated to this sensor exists already,
   // create it and set main properties
   if (!hit)

--- a/source/sensdet/ToFSD.cc
+++ b/source/sensdet/ToFSD.cc
@@ -22,7 +22,7 @@ using namespace CLHEP;
 ToFSD::ToFSD(G4String sdname) : G4VSensitiveDetector(sdname),
                                 naming_order_(0), sensor_depth_(0),
                                 mother_depth_(0),
-                                box_conf_(0)
+                                box_conf_(def), sipm_cells_(false)
 {
   // Register the name of the collection of hits
   collectionName.insert(GetCollectionUniqueName());
@@ -37,7 +37,7 @@ G4String ToFSD::GetCollectionUniqueName()
   return "PetSensorHitsCollection";
 }
 
-void ToFSD::Initialize(G4HCofThisEvent *HCE)
+void ToFSD::Initialize(G4HCofThisEvent* HCE)
 {
   // Create a new collection of PMT hits
   HC_ = new PetSensorHitsCollection(this->GetName(), this->GetCollectionName(0));
@@ -87,27 +87,45 @@ G4bool ToFSD::ProcessHits(G4Step *step, G4TouchableHistory *)
   return true;
 }
 
-G4int ToFSD::FindID(const G4VTouchable *touchable)
+G4int ToFSD::FindID(const G4VTouchable* touchable)
 {
-  // This is valid for full-body PET and FBK-only
+  // This is valid for full-body PET and for PETit with FBK-only
   G4int snsid = touchable->GetCopyNumber(sensor_depth_);
   if (naming_order_ != 0)
   {
     G4int motherid = touchable->GetCopyNumber(mother_depth_);
     snsid = naming_order_ * motherid + snsid;
   }
+
+  if (sipm_cells_) {
+    G4int pxlid         = touchable->GetCopyNumber(sensor_depth_);
+    G4int motherid      = touchable->GetCopyNumber(mother_depth_);
+    G4int grandmotherid = touchable->GetCopyNumber(grandmother_depth_);
+
+    snsid = naming_order_ * grandmotherid + motherid; // this is the SiPM ID
+    snsid = snsid * 10000 + pxlid; // this is the pixel ID
+  }
+
   if (box_conf_ == hama)
   { // Hamamatsu 2x2 and FBK centered
     std::vector<G4int> init_ids({0, 4, 40, 44, 100, 104, 140, 144});
     G4int motherid = touchable->GetCopyNumber(mother_depth_);
-    G4int first_id = (init_ids)[motherid];
-    snsid = first_id + snsid;
+    if (sipm_cells_) {
+      G4int pxlid         = touchable->GetCopyNumber(sensor_depth_);
+      G4int grandmotherid = touchable->GetCopyNumber(grandmother_depth_);
+      G4int first_id = (init_ids)[grandmotherid];
+      snsid = first_id + motherid; // this is the SiPM ID
+      snsid = snsid * 10000 + pxlid; // this is the ID of each microcell
+    } else {
+      G4int first_id = (init_ids)[motherid];
+      snsid = first_id + snsid;
+    }
   }
 
   return snsid;
 }
 
-void ToFSD::EndOfEvent(G4HCofThisEvent * /*HCE*/)
+void ToFSD::EndOfEvent(G4HCofThisEvent* /*HCE*/)
 {
   //  int HCID = G4SDManager::GetSDMpointer()->
   //    GetCollectionID(this->GetCollectionName(0));

--- a/source/sensdet/ToFSD.h
+++ b/source/sensdet/ToFSD.h
@@ -60,6 +60,9 @@ public:
   /// Set the box geometry parameter
   void SetBoxConf(petit_conf);
 
+  /// Set type of SiPM (with every microcell or not)
+  void SetSiPMCells(G4bool cells);
+
   /// Return the unique name of the hits collection created
   /// by this sensitive detector. This will be used by the
   /// persistency manager to select the collection.
@@ -75,7 +78,8 @@ private:
   G4int mother_depth_;      ///< Depth of the SD's mother in the geometry tree
   G4int grandmother_depth_; ///< Depth of the SD's grandmother in the geometry tree
 
-  G4int box_conf_; ///< Type of configuration
+  G4int box_conf_; ///< Type of configuration of the petit geometry
+  G4bool sipm_cells_; ///< True if each individual microcell is simulated in SiPMs
 
   PetSensorHitsCollection* HC_; ///< Pointer to the collection of hits
 };
@@ -95,5 +99,6 @@ inline void ToFSD::SetGrandMotherVolumeDepth(G4int d) { grandmother_depth_ = d; 
 inline G4int ToFSD::GetGrandMotherVolumeDepth() const { return grandmother_depth_; }
 
 inline void ToFSD::SetBoxConf(petit_conf bc) { box_conf_ = bc; }
+inline void ToFSD::SetSiPMCells(G4bool cells) { sipm_cells_ = cells; }
 
 #endif

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -55,6 +55,7 @@ def base_name_phantom():
 def file_name_phantom(output_tmpdir, base_name_phantom):
     return os.path.join(output_tmpdir, base_name_phantom+'.h5')
 
+
 @pytest.fixture(scope = 'session')
 def base_name_pyrex():
     return 'PETit_pyrex_test'
@@ -63,15 +64,24 @@ def base_name_pyrex():
 def file_name_pyrex(output_tmpdir, base_name_pyrex):
     return os.path.join(output_tmpdir, base_name_pyrex+'.h5')
 
+#@pytest.fixture(scope = 'session')
+#def petalosim_params_pyrex_HamamatsuBlue(output_tmpdir, base_name_pyrex):
+#    n_sipm         = 128
+#    sipms_per_tile =  16
+#    init_sns_id1   =  11
+#    init_sns_id2   = 111
+#    sensor_name    = 'SiPMHmtsuBlue'
+#    min_charge_evt = 50
+#    return os.path.join(output_tmpdir, base_name_pyrex+'.h5'),  n_sipm, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name, min_charge_evt
+
+
 @pytest.fixture(scope = 'session')
-def petalosim_params_pyrex_HamamatsuBlue(output_tmpdir, base_name_pyrex):
-    n_sipm         = 128
-    sipms_per_tile =  16
-    init_sns_id1   =  11
-    init_sns_id2   = 111
-    sensor_name    = 'SiPMHmtsuBlue'
-    min_charge_evt = 50
-    return os.path.join(output_tmpdir, base_name_pyrex+'.h5'),  n_sipm, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name, min_charge_evt
+def base_name_sat():
+    return 'PETit_sat_test'
+
+@pytest.fixture(scope = 'session')
+def file_name_sat(output_tmpdir, base_name_sat):
+    return os.path.join(output_tmpdir, base_name_sat+'.h5')
 
 
 @pytest.fixture(scope = 'session')

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -22,7 +22,7 @@ def base_name_full_body():
     return 'PET_full_body_sd_test'
 
 @pytest.fixture(scope = 'session')
-def petalosim_params_full_body(output_tmpdir, base_name_full_body):
+def params_full_body(output_tmpdir, base_name_full_body):
     n_sipm          = 102304
     n_boards        = 0
     sipms_per_board = 0
@@ -39,12 +39,25 @@ def file_name_nest(output_tmpdir, base_name_nest):
     return os.path.join(output_tmpdir, base_name_nest+'.h5')
 
 @pytest.fixture(scope = 'session')
-def petalosim_params_nest(output_tmpdir, base_name_nest):
+def params_nest(output_tmpdir, base_name_nest):
     n_sipm          = 102304
     n_boards        = 0
     sipms_per_board = 0
     board_ordering  = 0
     return os.path.join(output_tmpdir, base_name_nest+'.h5'), n_sipm, n_boards, sipms_per_board, board_ordering
+
+
+@pytest.fixture(scope = 'session')
+def base_name_ring_tiles():
+    return 'PET_ring_tiles_sd_test'
+
+@pytest.fixture(scope = 'session')
+def params_ring_tiles(output_tmpdir, base_name_ring_tiles):
+    n_sipm          = 3840
+    n_boards        = 120
+    sipms_per_board = 32
+    board_ordering  = 1000
+    return os.path.join(output_tmpdir, base_name_ring_tiles+'.h5'), n_sipm, n_boards, sipms_per_board, board_ordering
 
 
 @pytest.fixture(scope = 'session')
@@ -66,74 +79,61 @@ def file_name_pyrex(output_tmpdir, base_name_pyrex):
 
 
 @pytest.fixture(scope = 'session')
-def base_name_sat_hama():
-    return 'PETit_sat_hama_test'
+def base_name_sat_Hama():
+    return 'PETit_sat_Hama_test'
 
 @pytest.fixture(scope = 'session')
-def file_name_sat_hama(output_tmpdir, base_name_sat_hama):
-    return os.path.join(output_tmpdir, base_name_sat_hama+'.h5')
+def file_name_sat_Hama(output_tmpdir, base_name_sat_Hama):
+    return os.path.join(output_tmpdir, base_name_sat_Hama+'.h5')
 
 @pytest.fixture(scope = 'session')
-def petit_params_hama(output_tmpdir, base_name_sat_hama):
+def petit_params_sat_Hama(output_tmpdir, base_name_sat_Hama):
     geom_type  = 'PETit'
     n_pixels   = 788736
     n_sipms    = 128
     separation_pxls  = 1000000
     separation_sipms = 100
-    return os.path.join(output_tmpdir, base_name_sat_hama+'.h5'), base_name_sat_hama, geom_type, n_pixels, n_sipms, separation_pxls, separation_sipms
+    return os.path.join(output_tmpdir, base_name_sat_Hama+'.h5'), base_name_sat_Hama, geom_type, n_pixels, n_sipms, separation_pxls, separation_sipms
 
 
 @pytest.fixture(scope = 'session')
-def base_name_sat_fbk():
-    return 'PETit_sat_fbk_test'
+def base_name_sat_FBK():
+    return 'PETit_sat_FBK_test'
 
 @pytest.fixture(scope = 'session')
-def file_name_sat_fbk(output_tmpdir, base_name_sat_fbk):
-    return os.path.join(output_tmpdir, base_name_sat_fbk+'.h5')
+def file_name_sat_FBK(output_tmpdir, base_name_sat_FBK):
+    return os.path.join(output_tmpdir, base_name_sat_FBK+'.h5')
 
 @pytest.fixture(scope = 'session')
-def petit_params_fbk(output_tmpdir, base_name_sat_fbk):
+def petit_params_sat_FBK(output_tmpdir, base_name_sat_FBK):
     geom_type  = 'PETitFBK'
     n_pixels   = 4221440
     n_sipms    = 512
     separation_pxls = 5000000
     separation_sipms = 500
-    return os.path.join(output_tmpdir, base_name_sat_fbk+'.h5'), base_name_sat_fbk, geom_type, n_pixels, n_sipms, separation_pxls, separation_sipms
+    return os.path.join(output_tmpdir, base_name_sat_FBK+'.h5'), base_name_sat_FBK, geom_type, n_pixels, n_sipms, separation_pxls, separation_sipms
 
 
 @pytest.fixture(scope = 'session')
-def base_name_ring_tiles():
-    return 'PET_ring_tiles_sd_test'
+def base_name_petit_HamamatsuVUV():
+    return 'PETit_HamamatsuVUV_sd_test'
 
 @pytest.fixture(scope = 'session')
-def petalosim_params_ring_tiles(output_tmpdir, base_name_ring_tiles):
-    n_sipm          = 3840
-    n_boards        = 120
-    sipms_per_board = 32
-    board_ordering  = 1000
-    return os.path.join(output_tmpdir, base_name_ring_tiles+'.h5'), n_sipm, n_boards, sipms_per_board, board_ordering
-
+def base_name_petit_HamamatsuBlue():
+    return 'PETit_HamamatsuBlue_sd_test'
 
 @pytest.fixture(scope = 'session')
-def base_name_pet_box_HamamatsuVUV():
-    return 'PET_box_HamamatsuVUV_sd_test'
+def base_name_petit_FBK():
+    return 'PETit_FBK_sd_test'
 
 @pytest.fixture(scope = 'session')
-def base_name_pet_box_HamamatsuBlue():
-    return 'PET_box_HamamatsuBlue_sd_test'
-
-@pytest.fixture(scope = 'session')
-def base_name_pet_box_FBK():
-    return 'PET_box_FBK_sd_test'
-
-@pytest.fixture(scope = 'session')
-def base_name_pet_box_mix_Ham_FBK():
-    return 'PET_box_mix_Ham_FBK_sd_test'
+def base_name_petit_mix_Hama_FBK():
+    return 'PETit_mix_Hama_FBK_sd_test'
 
 
 @pytest.fixture(scope = 'session')
-def petalosim_params_pet_box_HamamatsuVUV(output_tmpdir):
-    base_name      = 'PET_box_HamamatsuVUV_sd_test'
+def petit_params_HamamatsuVUV(output_tmpdir):
+    base_name      = 'PETit_HamamatsuVUV_sd_test'
     geom_type      = 'PETit'
     n_sipm         = 128
     sipms_per_tile =  16
@@ -145,8 +145,8 @@ def petalosim_params_pet_box_HamamatsuVUV(output_tmpdir):
 
 
 @pytest.fixture(scope = 'session')
-def petalosim_params_pet_box_FBK(output_tmpdir):
-    base_name      = 'PET_box_FBK_sd_test'
+def petit_params_FBK(output_tmpdir):
+    base_name      = 'PETit_FBK_sd_test'
     geom_type      = 'PETitFBK'
     n_sipm         = 512
     sipms_per_tile =  64
@@ -157,8 +157,8 @@ def petalosim_params_pet_box_FBK(output_tmpdir):
     return os.path.join(output_tmpdir, base_name+'.h5'), base_name, geom_type, n_sipm, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name, min_charge_evt
 
 @pytest.fixture(scope = 'session')
-def petalosim_params_pet_box_mix_Ham_FBK(output_tmpdir):
-    base_name      = 'PET_box_mix_Ham_FBK_sd_test'
+def petit_params_mix_Hama_FBK(output_tmpdir):
+    base_name      = 'PETit_mix_Hama_FBK_sd_test'
     geom_type      = 'PETitPyrexMix'
     n_sipm         = 320
     sipms_per_tile = 64
@@ -172,46 +172,36 @@ def petalosim_params_pet_box_mix_Ham_FBK(output_tmpdir):
 @pytest.fixture(scope="module",
                 params=["base_name_full_body", "base_name_nest",
                         "base_name_ring_tiles",
-                        "base_name_pet_box_HamamatsuVUV",
-                        "base_name_pet_box_FBK",
-                        "base_name_pet_box_mix_Ham_FBK", "base_name_pyrex"],
-                ids=["full_body", "nest", "ring_tiles", "pet_box_HamamatsuVUV",
-                     "pet_box_FBK", "pet_box_mix_Ham_FBK", "petit_pyrex"])
+                        "base_name_petit_HamamatsuVUV",
+                        "base_name_petit_FBK",
+                        "base_name_petit_mix_Hama_FBK", "base_name_pyrex"],
+                ids=["full_body", "nest", "ring_tiles", "petit_HamamatsuVUV",
+                     "petit_FBK", "petit_mix_Ham_FBK", "petit_pyrex"])
 def petalosim_files(request, output_tmpdir):
     return os.path.join(output_tmpdir, request.getfixturevalue(request.param)+'.h5')
 
 
 @pytest.fixture(scope="module",
-                params=["petalosim_params_full_body", "petalosim_params_nest",
-                        "petalosim_params_ring_tiles"],
+                params=["params_full_body", "params_nest",
+                        "params_ring_tiles"],
                 ids=["full_body", "nest", "ring_tiles"])
-def petalosim_params(request):
+def general_params(request):
     return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(scope="module",
-                params=["petalosim_params_pet_box_HamamatsuVUV",
-                        "petalosim_params_pet_box_FBK",
-                        "petalosim_params_pet_box_mix_Ham_FBK"],
-                ids=["pet_box_HamamatsuVUV", "pet_box_FBK",
-                     'pet_box_mix_Ham_FBK'])
-def petalosim_pet_box_params(request):
+                params=["petit_params_HamamatsuVUV",
+                        "petit_params_FBK",
+                        "petit_params_mix_Hama_FBK"],
+                ids=["petit_HamamatsuVUV", "petit_FBK",
+                     'petit_mix_Ham_FBK'])
+def petit_params(request):
     return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(scope="module",
-                params=["petalosim_params_pet_box_HamamatsuVUV",
-                        "petalosim_params_pet_box_FBK",
-                        "petalosim_params_pet_box_mix_Ham_FBK"],
-                ids=["pet_box_HamamatsuVUV", "pet_box_FBK",
-                     'pet_box_mix_Ham_FBK'])
-def petalosim_pet_box_params(request):
-    return request.getfixturevalue(request.param)
-
-
-@pytest.fixture(scope="module",
-                params=["petit_params_hama", "petit_params_fbk"],
-                ids=["petit_sat_HamamatsuVUV", "petit_sat_fbk"])
+                params=["petit_params_sat_Hama", "petit_params_sat_FBK"],
+                ids=["petit_sat_HamamatsuVUV", "petit_sat_FBK"])
 def petit_sat_params(request):
     return request.getfixturevalue(request.param)
 

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -64,24 +64,41 @@ def base_name_pyrex():
 def file_name_pyrex(output_tmpdir, base_name_pyrex):
     return os.path.join(output_tmpdir, base_name_pyrex+'.h5')
 
-#@pytest.fixture(scope = 'session')
-#def petalosim_params_pyrex_HamamatsuBlue(output_tmpdir, base_name_pyrex):
-#    n_sipm         = 128
-#    sipms_per_tile =  16
-#    init_sns_id1   =  11
-#    init_sns_id2   = 111
-#    sensor_name    = 'SiPMHmtsuBlue'
-#    min_charge_evt = 50
-#    return os.path.join(output_tmpdir, base_name_pyrex+'.h5'),  n_sipm, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name, min_charge_evt
+
+@pytest.fixture(scope = 'session')
+def base_name_sat_hama():
+    return 'PETit_sat_hama_test'
+
+@pytest.fixture(scope = 'session')
+def file_name_sat_hama(output_tmpdir, base_name_sat_hama):
+    return os.path.join(output_tmpdir, base_name_sat_hama+'.h5')
+
+@pytest.fixture(scope = 'session')
+def petit_params_hama(output_tmpdir, base_name_sat_hama):
+    geom_type  = 'PETit'
+    n_pixels   = 788736
+    n_sipms    = 128
+    separation_pxls  = 1000000
+    separation_sipms = 100
+    return os.path.join(output_tmpdir, base_name_sat_hama+'.h5'), base_name_sat_hama, geom_type, n_pixels, n_sipms, separation_pxls, separation_sipms
 
 
 @pytest.fixture(scope = 'session')
-def base_name_sat():
-    return 'PETit_sat_test'
+def base_name_sat_fbk():
+    return 'PETit_sat_fbk_test'
 
 @pytest.fixture(scope = 'session')
-def file_name_sat(output_tmpdir, base_name_sat):
-    return os.path.join(output_tmpdir, base_name_sat+'.h5')
+def file_name_sat_fbk(output_tmpdir, base_name_sat_fbk):
+    return os.path.join(output_tmpdir, base_name_sat_fbk+'.h5')
+
+@pytest.fixture(scope = 'session')
+def petit_params_fbk(output_tmpdir, base_name_sat_fbk):
+    geom_type  = 'PETitFBK'
+    n_pixels   = 4221440
+    n_sipms    = 512
+    separation_pxls = 5000000
+    separation_sipms = 500
+    return os.path.join(output_tmpdir, base_name_sat_fbk+'.h5'), base_name_sat_fbk, geom_type, n_pixels, n_sipms, separation_pxls, separation_sipms
 
 
 @pytest.fixture(scope = 'session')
@@ -153,10 +170,13 @@ def petalosim_params_pet_box_mix_Ham_FBK(output_tmpdir):
 
 
 @pytest.fixture(scope="module",
-                params=["base_name_full_body", "base_name_nest", "base_name_ring_tiles",
+                params=["base_name_full_body", "base_name_nest",
+                        "base_name_ring_tiles",
                         "base_name_pet_box_HamamatsuVUV",
-                        "base_name_pet_box_FBK", "base_name_pet_box_mix_Ham_FBK", "base_name_pyrex"],
-                ids=["full_body", "nest", "ring_tiles", "pet_box_HamamatsuVUV", "pet_box_FBK", "pet_box_mix_Ham_FBK", "petit_pyrex"])
+                        "base_name_pet_box_FBK",
+                        "base_name_pet_box_mix_Ham_FBK", "base_name_pyrex"],
+                ids=["full_body", "nest", "ring_tiles", "pet_box_HamamatsuVUV",
+                     "pet_box_FBK", "pet_box_mix_Ham_FBK", "petit_pyrex"])
 def petalosim_files(request, output_tmpdir):
     return os.path.join(output_tmpdir, request.getfixturevalue(request.param)+'.h5')
 
@@ -171,7 +191,28 @@ def petalosim_params(request):
 
 @pytest.fixture(scope="module",
                 params=["petalosim_params_pet_box_HamamatsuVUV",
-                        "petalosim_params_pet_box_FBK", "petalosim_params_pet_box_mix_Ham_FBK"],
-                ids=["pet_box_HamamatsuVUV", "pet_box_FBK", 'pet_box_mix_Ham_FBK'])
+                        "petalosim_params_pet_box_FBK",
+                        "petalosim_params_pet_box_mix_Ham_FBK"],
+                ids=["pet_box_HamamatsuVUV", "pet_box_FBK",
+                     'pet_box_mix_Ham_FBK'])
 def petalosim_pet_box_params(request):
     return request.getfixturevalue(request.param)
+
+
+@pytest.fixture(scope="module",
+                params=["petalosim_params_pet_box_HamamatsuVUV",
+                        "petalosim_params_pet_box_FBK",
+                        "petalosim_params_pet_box_mix_Ham_FBK"],
+                ids=["pet_box_HamamatsuVUV", "pet_box_FBK",
+                     'pet_box_mix_Ham_FBK'])
+def petalosim_pet_box_params(request):
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture(scope="module",
+                params=["petit_params_hama", "petit_params_fbk"],
+                ids=["petit_sat_HamamatsuVUV", "petit_sat_fbk"])
+def petit_sat_params(request):
+    return request.getfixturevalue(request.param)
+
+

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -139,9 +139,9 @@ def test_create_petalo_output_file_ring_tiles(config_tmpdir, output_tmpdir, PETA
 
 
 @pytest.mark.order(3)
-def test_create_petalo_output_file_pet_box_all_tiles(config_tmpdir, output_tmpdir, PETALODIR, petalosim_pet_box_params):
+def test_create_petalo_output_file_petit_all_tiles(config_tmpdir, output_tmpdir, PETALODIR, petit_params):
 
-     _, base_name, geom_type, _, _, _, _, _, min_charge_evt = petalosim_pet_box_params
+     _, base_name, geom_type, _, _, _, _, _, min_charge_evt = petit_params
 
      init_text = f"""
 /PhysicsList/RegisterPhysics G4EmStandardPhysics_option4

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -122,8 +122,6 @@ def test_create_petalo_output_file_ring_tiles(config_tmpdir, output_tmpdir, PETA
 
 /Generator/Back2back/region CENTER
 
-/process/optical/processActivation Cerenkov false
-
 /petalosim/persistency/output_file {output_tmpdir}/{base_name_ring_tiles}
 /nexus/random_seed 16062020
 
@@ -186,8 +184,6 @@ def test_create_petalo_output_file_pet_box_all_tiles(config_tmpdir, output_tmpdi
 /Generator/IonGenerator/mass_number 22
 
 /Actions/PetSensorsEventAction/min_charge {min_charge_evt}
-
-/process/optical/processActivation Cerenkov false
 
 /petalosim/persistency/output_file {output_tmpdir}/{base_name}
 
@@ -252,8 +248,6 @@ def test_create_petalo_output_file_petit_pyrex(config_tmpdir, output_tmpdir, PET
 
 /Actions/PetSensorsEventAction/min_charge 50
 
-/process/optical/processActivation Cerenkov false
-
 /petalosim/persistency/output_file {output_tmpdir}/{base_name_pyrex}
 
 /nexus/random_seed 23102022
@@ -271,7 +265,9 @@ def test_create_petalo_output_file_petit_pyrex(config_tmpdir, output_tmpdir, PET
 
 
 @pytest.mark.order(5)
-def test_create_petalo_output_file_petit_saturation(config_tmpdir, output_tmpdir, PETALODIR, base_name_sat):
+def test_create_petalo_output_file_petit_saturation(config_tmpdir, output_tmpdir, PETALODIR, petit_sat_params):
+
+     _, base_name, geom_type, _, _, _, _ = petit_sat_params
 
      init_text = f"""
 /PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
@@ -282,7 +278,7 @@ def test_create_petalo_output_file_petit_saturation(config_tmpdir, output_tmpdir
 /PhysicsList/RegisterPhysics G4StepLimiterPhysics
 
 ### GEOMETRY
-/nexus/RegisterGeometry PETit
+/nexus/RegisterGeometry {geom_type}
 
 ### GENERATOR
 /nexus/RegisterGenerator IonGenerator
@@ -295,9 +291,9 @@ def test_create_petalo_output_file_petit_saturation(config_tmpdir, output_tmpdir
 
 /nexus/RegisterPersistencyManager PetaloPersistencyManager
 
-/nexus/RegisterMacro {config_tmpdir}/{base_name_sat}.config.mac
+/nexus/RegisterMacro {config_tmpdir}/{base_name}.config.mac
 """
-     init_path = os.path.join(config_tmpdir, base_name_sat+'.init.mac')
+     init_path = os.path.join(config_tmpdir, base_name+'.init.mac')
      init_file = open(init_path,'w')
      init_file.write(init_text)
      init_file.close()
@@ -309,25 +305,21 @@ def test_create_petalo_output_file_petit_saturation(config_tmpdir, output_tmpdir
 
 /process/em/verbose 0
 
-/Geometry/PETit/sipm_cells true
+/Geometry/{geom_type}/sipm_cells true
 
 /Generator/IonGenerator/region SOURCE
 /Generator/IonGenerator/atomic_number 11
 /Generator/IonGenerator/mass_number 22
 
-/Actions/PetSensorsEventAction/min_charge 50
-
-/process/optical/processActivation Cerenkov false
-
 /petalosim/persistency/sipm_cells true
 /petalosim/persistency/save_tot_charge false
 
-/petalosim/persistency/output_file {output_tmpdir}/{base_name_sat}
+/petalosim/persistency/output_file {output_tmpdir}/{base_name}
 
 /nexus/random_seed 23102022
 """
 
-     config_path = os.path.join(config_tmpdir, base_name_sat+'.config.mac')
+     config_path = os.path.join(config_tmpdir, base_name+'.config.mac')
      config_file = open(config_path,'w')
      config_file.write(config_text)
      config_file.close()
@@ -391,9 +383,9 @@ def test_create_petalo_output_file_nest(config_tmpdir, output_tmpdir, PETALODIR,
 /Generator/Back2back/region AD_HOC
 
 /process/optical/processActivation Scintillation false
-/PhysicsList/Petalo/nest true
-
 /process/optical/processActivation Cerenkov false
+
+/PhysicsList/Petalo/nest true
 
 /petalosim/persistency/output_file {output_tmpdir}/{base_name_nest}
 /nexus/random_seed 16062020

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -271,6 +271,74 @@ def test_create_petalo_output_file_petit_pyrex(config_tmpdir, output_tmpdir, PET
 
 
 @pytest.mark.order(5)
+def test_create_petalo_output_file_petit_saturation(config_tmpdir, output_tmpdir, PETALODIR, base_name_sat):
+
+     init_text = f"""
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics G4OpticalPhysics
+/PhysicsList/RegisterPhysics PetaloPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+### GEOMETRY
+/nexus/RegisterGeometry PETit
+
+### GENERATOR
+/nexus/RegisterGenerator IonGenerator
+#/nexus/RegisterGenerator SingleParticleGenerator
+
+### ACTIONS
+/nexus/RegisterRunAction DefaultRunAction
+/nexus/RegisterEventAction PetSensorsEventAction
+/nexus/RegisterTrackingAction PetaloTrackingAction
+
+/nexus/RegisterPersistencyManager PetaloPersistencyManager
+
+/nexus/RegisterMacro {config_tmpdir}/{base_name_sat}.config.mac
+"""
+     init_path = os.path.join(config_tmpdir, base_name_sat+'.init.mac')
+     init_file = open(init_path,'w')
+     init_file.write(init_text)
+     init_file.close()
+
+     config_text = f"""
+/run/verbose 1
+/event/verbose 0
+/tracking/verbose 0
+
+/process/em/verbose 0
+
+/Geometry/PETit/sipm_cells true
+
+/Generator/IonGenerator/region SOURCE
+/Generator/IonGenerator/atomic_number 11
+/Generator/IonGenerator/mass_number 22
+
+/Actions/PetSensorsEventAction/min_charge 50
+
+/process/optical/processActivation Cerenkov false
+
+/petalosim/persistency/sipm_cells true
+/petalosim/persistency/save_tot_charge false
+
+/petalosim/persistency/output_file {output_tmpdir}/{base_name_sat}
+
+/nexus/random_seed 23102022
+"""
+
+     config_path = os.path.join(config_tmpdir, base_name_sat+'.config.mac')
+     config_file = open(config_path,'w')
+     config_file.write(config_text)
+     config_file.close()
+
+     my_env    = os.environ
+     petalo_exe = PETALODIR + '/bin/petalo'
+     command   = [petalo_exe, '-b', '-n', '20', init_path]
+     p         = subprocess.run(command, check=True, env=my_env)
+
+
+@pytest.mark.order(6)
 def test_create_petalo_output_file_nest(config_tmpdir, output_tmpdir, PETALODIR, base_name_nest):
 
      init_text = f"""

--- a/tests/pytest/sensitive_detectors_test.py
+++ b/tests/pytest/sensitive_detectors_test.py
@@ -3,11 +3,11 @@ import numpy  as np
 import os
 
 
-def test_sensor_ids(petalosim_params):
+def test_sensor_ids(general_params):
      """
      Check that sensors are correctly numbered.
      """
-     filename, nsipms, n_boards, sipms_per_board, board_ordering = petalosim_params
+     filename, nsipms, n_boards, sipms_per_board, board_ordering = general_params
 
      sns_response = pd.read_hdf(filename, 'MC/sns_response')
      sipm_ids     = sns_response.sensor_id.unique()
@@ -28,13 +28,13 @@ def test_sensor_ids(petalosim_params):
           assert (sipm_ids % board_ordering).max() <=  sipms_per_board
 
 
-def test_sensor_ids_pet_box(petalosim_pet_box_params):
+def test_sensor_ids_petit(petit_params):
      """
      Check that sensors are correctly numbered for the geometry,
      the charge of the event is above a threshold and that the true
      information is stored if charge is detected by the sensors.
      """
-     filename, _, _, nsipms, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name, min_charge_evt = petalosim_pet_box_params
+     filename, _, _, nsipms, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name, min_charge_evt = petit_params
 
      sns_response = pd.read_hdf(filename, 'MC/sns_response')
      sipm_ids     = sns_response.sensor_id.unique()

--- a/tests/pytest/sensitive_detectors_test.py
+++ b/tests/pytest/sensitive_detectors_test.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy  as np
+import os
 
 
 def test_sensor_ids(petalosim_params):
@@ -74,13 +75,19 @@ def test_sensor_ids_pet_box(petalosim_pet_box_params):
      assert mcparticles.event_id.nunique() == sns_response.event_id.nunique()
 
 
-def test_sensor_ids_petit_pyrex_blue(petalosim_params_pyrex_HamamatsuBlue):
+def test_sensor_ids_petit_pyrex_blue(output_tmpdir, base_name_pyrex):
      """
      Check that sensors are correctly numbered for the geometry,
      the charge of the event is above a threshold and that the true
      information is stored if charge is detected by the sensors.
      """
-     filename, nsipms, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name, min_charge_evt = petalosim_params_pyrex_HamamatsuBlue
+
+     nsipms         = 128
+     sipms_per_tile =  16
+     init_sns_id1   =  11
+     sensor_name    = 'SiPMHmtsuBlue'
+     min_charge_evt = 50
+     filename = os.path.join(output_tmpdir, base_name_pyrex+'.h5')
 
      sns_response = pd.read_hdf(filename, 'MC/sns_response')
      sipm_ids     = sns_response.sensor_id.unique()

--- a/tests/pytest/sensitive_detectors_test.py
+++ b/tests/pytest/sensitive_detectors_test.py
@@ -127,3 +127,27 @@ def test_sensor_ids_petit_pyrex_blue(output_tmpdir, base_name_pyrex):
      # Check that all the stored events have detected charge
      mcparticles = pd.read_hdf(filename, 'MC/particles')
      assert mcparticles.event_id.nunique() == sns_response.event_id.nunique()
+
+
+def test_sensor_ids_petit_saturation(output_tmpdir, petit_sat_params):
+     """
+     Check that both pixels and sensors are correctly numbered for the geometry.
+     """
+
+     filename, _, _, npxls, nsipms, sep_pxls, sep_sipms = petit_sat_params
+
+     sns_response = pd.read_hdf(filename, 'MC/tof_sns_response')
+     pxl_ids     = sns_response.sensor_id.unique()
+     pxl_ids1    = pxl_ids[pxl_ids < sep_pxls]
+     pxl_ids2    = pxl_ids[pxl_ids > sep_pxls]
+
+     assert 1 <= len(pxl_ids1) <= npxls / 2.
+     assert 1 <= len(pxl_ids2) <= npxls / 2.
+
+     sipm_ids = sns_response.sensor_id // 10000
+
+     sipm_ids1 = sipm_ids[sipm_ids < sep_sipms]
+     sipm_ids2 = sipm_ids[sipm_ids > sep_sipms]
+
+     assert 1 <= len(set(sipm_ids1)) <= nsipms / 2.
+     assert 1 <= len(set(sipm_ids2)) <= nsipms / 2.


### PR DESCRIPTION
This PR adds the simulation of saturation for FBK and Hamamatsu SiPMs. Each cell is simulated, so that a proper recovery time can be used a posteriori to reproduce a more accurate sensor response.
This PR must be merged after #29.