### PR TITLE
Files to be used when using the VUV filter

### DIFF
--- a/macros/PETitFilter.config.mac
+++ b/macros/PETitFilter.config.mac
@@ -1,0 +1,29 @@
+### GEOMETRY
+/Geometry/PETitFilter/box_vis true
+/Geometry/PETitFilter/tile_vis false
+
+/Geometry/PETitFilter/tile_refl 0
+
+### GENERATOR
+/Generator/IonGenerator/region SOURCE
+/Generator/IonGenerator/atomic_number 11
+/Generator/IonGenerator/mass_number 22
+
+
+### PHYSICS
+#/process/optical/processActivation Scintillation true
+#/process/optical/processActivation Cerenkov      true
+
+### VERBOSITIES
+/run/verbose 0
+/event/verbose 0
+/tracking/verbose 0
+
+/process/em/verbose 0
+
+/nexus/random_seed 132323
+
+### OUTPUT FILE
+/petalosim/persistency/start_id 0
+/petalosim/persistency/output_file petit_filter_lineal
+

--- a/macros/PETitFilter.init.mac
+++ b/macros/PETitFilter.init.mac
@@ -1,0 +1,24 @@
+### PHYSICS
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4OpticalPhysics
+/PhysicsList/RegisterPhysics PetaloPhysics
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+### GEOMETRY
+/nexus/RegisterGeometry PETitFilter
+
+### GENERATOR
+/nexus/RegisterGenerator IonGenerator
+
+
+### ACTIONS
+/nexus/RegisterRunAction DefaultRunAction
+#/nexus/RegisterEventAction PetSensorsEventAction
+/nexus/RegisterEventAction PetaloEventAction
+/nexus/RegisterTrackingAction PetaloTrackingAction
+
+/nexus/RegisterPersistencyManager PetaloPersistencyManager
+
+/nexus/RegisterMacro macros/PETitFilter.config.mac

--- a/macros/TeflonBlockHamamatsuFilter.config.mac
+++ b/macros/TeflonBlockHamamatsuFilter.config.mac
@@ -1,0 +1,28 @@
+### GEOMETRY
+#/Geometry/TeflonBlockHamamatsuFilter/visibility_ false
+
+
+### GENERATOR
+/Generator/SingleParticle/particle opticalphoton
+/Generator/SingleParticle/min_energy 6.199 eV
+/Generator/SingleParticle/max_energy 6.199 eV
+/Generator/SingleParticle/region CENTER
+/Generator/SingleParticle/momentum 0 0 +1 mm
+
+### PHYSICS
+#/process/optical/processActivation Scintillation true
+#/process/optical/processActivation Cerenkov      true
+
+### VERBOSITIES
+/run/verbose 0
+/event/verbose 0
+/tracking/verbose 0
+
+/process/em/verbose 0
+
+/nexus/random_seed 132323
+
+### OUTPUT FILE
+#/petalosim/persistency/start_id 0
+#/petalosim/persistency/output_file petit
+

--- a/macros/TeflonBlockHamamatsuFilter.init.mac
+++ b/macros/TeflonBlockHamamatsuFilter.init.mac
@@ -1,0 +1,24 @@
+### PHYSICS
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4OpticalPhysics
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+/PhysicsList/RegisterPhysics PetaloPhysics
+
+### GEOMETRY
+/nexus/RegisterGeometry TeflonBlockHamamatsuFilter
+
+### GENERATOR
+/nexus/RegisterGenerator SingleParticleGenerator
+
+### ACTIONS
+/nexus/RegisterRunAction DefaultRunAction
+#/nexus/RegisterEventAction PetSensorsEventAction
+#/nexus/RegisterEventAction PetaloEventAction
+/nexus/RegisterTrackingAction PetaloTrackingAction
+/nexus/RegisterSteppingAction PetAnalysisSteppingAction
+
+#/nexus/RegisterPersistencyManager PetaloPersistencyManager
+
+/nexus/RegisterMacro macros/TeflonBlockHamamatsuFilter.config.mac

--- a/source/geometries/PETitFilter.cc
+++ b/source/geometries/PETitFilter.cc
@@ -1,0 +1,255 @@
+// ----------------------------------------------------------------------------
+// petalosim | PETitFilter.cc
+//
+// This class implements the geometry of a box of LXe with Hamamatsu tiles
+// with the VUV filter.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#include "PETitFilter.h"
+#include "PETitBox.h"
+#include "TileHamamatsuVUV.h"
+#include "PetMaterialsList.h"
+#include "PetOpticalMaterialProperties.h"
+#include "TeflonBlockHamamatsu.h"
+#include "TeflonBlockHamamatsuFilter.h"
+#include "PetaloUtils.h"
+#include "NeutralFilterVUV.h"
+#include "nexus/Visibilities.h"
+#include "nexus/IonizationSD.h"
+#include "nexus/FactoryBase.h"
+#include "nexus/SpherePointSampler.h"
+
+#include <G4GenericMessenger.hh>
+#include <G4LogicalVolume.hh>
+#include <G4PVPlacement.hh>
+#include <G4VisAttributes.hh>
+#include <G4NistManager.hh>
+#include <G4Box.hh>
+#include <G4Material.hh>
+#include <G4SDManager.hh>
+#include <G4UserLimits.hh>
+#include <G4OpticalSurface.hh>
+#include <G4LogicalSkinSurface.hh>
+
+using namespace nexus;
+
+REGISTER_CLASS(PETitFilter, GeometryBase)
+
+PETitFilter::PETitFilter() : GeometryBase(),
+                 visibility_(0),
+                 box_vis_(0),
+                 tile_vis_(1),
+                 tile_refl_(0.),
+                 dist_dice_flange_(18.6 * mm),
+                 n_tile_rows_(2),
+                 n_tile_columns_(2),
+                 specific_vertex_{},
+                 sipm_cells_(false),
+                 max_step_size_(1. * mm),
+                 pressure_(1 * bar)
+
+{
+  // Messenger
+  msg_ = new G4GenericMessenger(this, "/Geometry/PETitFilter/",
+                                "Control commands of geometry PETitFilter.");
+  msg_->DeclareProperty("visibility", visibility_, "Visibility");
+  msg_->DeclareProperty("box_vis", box_vis_,
+                        "Visibility of the basic structure");
+  msg_->DeclareProperty("tile_vis", tile_vis_, "Visibility of tiles");
+  msg_->DeclareProperty("tile_refl", tile_refl_, "Reflectivity of SiPM boards");
+  msg_->DeclareProperty("sipm_cells", sipm_cells_,
+                        "True if each cell of SiPMs is simulated");
+
+  msg_->DeclarePropertyWithUnit("specific_vertex", "mm",  specific_vertex_,
+                                "Set generation vertex.");
+
+  G4GenericMessenger::Command &press_cmd =
+    msg_->DeclareProperty("pressure", pressure_,
+                          "Pressure of LXe");
+  press_cmd.SetUnitCategory("Pressure");
+  press_cmd.SetParameterName("pressure", false);
+  press_cmd.SetRange("pressure>0.");
+
+
+}
+
+PETitFilter::~PETitFilter()
+{
+}
+
+void PETitFilter::Construct()
+{
+  // Volume of air surrounding the detector //
+  G4double lab_size = 1. * m;
+  G4Box *lab_solid = new G4Box("LAB", lab_size/2., lab_size/2., lab_size/2.);
+
+  G4Material *air = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+  lab_logic_ = new G4LogicalVolume(lab_solid, air, "LAB");
+  lab_logic_->SetVisAttributes(G4VisAttributes::GetInvisible());
+  this->SetLogicalVolume(lab_logic_);
+
+  BuildBox();
+  BuildSensors();
+}
+
+void PETitFilter::BuildBox()
+{
+  G4Material* LXe = G4NistManager::Instance()->FindOrBuildMaterial("G4_lXe");
+  LXe->SetMaterialPropertiesTable(petopticalprops::LXe(pressure_));
+
+  // Set the ACTIVE volume as an ionization sensitive det
+  IonizationSD* ionisd = new IonizationSD("/PETALO/ACTIVE");
+  G4SDManager::GetSDMpointer()->AddNewDetector(ionisd);
+
+
+  box_ = new PETitBox();
+  box_->SetLXePressure(pressure_);
+  box_->SetXeMaterial(LXe);
+  box_->SetIoniSD(ionisd);
+  box_->SetVisibility(box_vis_);
+  box_->Construct();
+  G4LogicalVolume* box_logic = box_->GetLogicalVolume();
+
+  new G4PVPlacement(0, G4ThreeVector(0., 0, 0.),
+                    box_logic, "ALUMINUM_BOX", lab_logic_,
+                    false, 0, false);
+
+  active_logic_ = box_->GetActiveVolume();
+  G4double ih_z_size = box_->GetHatZSize();
+
+  // Add both teflon blocks
+  TeflonBlockHamamatsu teflon_block_hama = TeflonBlockHamamatsu();
+  teflon_block_hama.SetHoleMaterial(LXe);
+  teflon_block_hama.SetIoniSD(ionisd);
+  teflon_block_hama.SetMaxStepSize(max_step_size_);
+  teflon_block_hama.Construct();
+  G4LogicalVolume* teflon_block_logic = teflon_block_hama.GetLogicalVolume();
+
+  G4double teflon_block_thick = teflon_block_hama.GetTeflonThickness();
+  G4double block_z_pos = ih_z_size/2. + teflon_block_thick/2.;
+  new G4PVPlacement(0, G4ThreeVector(0., 0., -block_z_pos), teflon_block_logic,
+                    "TEFLON_BLOCK_HAMA", active_logic_, false, 0, false);
+
+  TeflonBlockHamamatsuFilter teflon_block_hama_filt = TeflonBlockHamamatsuFilter();
+  teflon_block_hama_filt.SetHoleMaterial(LXe);
+  teflon_block_hama_filt.SetIoniSD(ionisd);
+  teflon_block_hama_filt.SetMaxStepSize(max_step_size_);
+  teflon_block_hama_filt.Construct();
+  G4LogicalVolume* teflon_block_hama_filt_logic = teflon_block_hama_filt.GetLogicalVolume();
+
+  G4double teflon_block_filter_thick = teflon_block_hama_filt.GetTeflonThickness();
+  G4double teflon_recess_depth = teflon_block_hama_filt.GetTeflonRecessDepth();
+  G4double block_z_pos_filt = ih_z_size/2. + teflon_block_filter_thick/2.;
+
+  G4RotationMatrix rot_teflon;
+  rot_teflon.rotateY(pi);
+  new G4PVPlacement(G4Transform3D(rot_teflon,
+                                  G4ThreeVector(0., 0., block_z_pos_filt)),
+                    teflon_block_hama_filt_logic,
+                    "TEFLON_BLOCK_HAMA_FILT", active_logic_, false, 0, false);
+
+  // Optical surface for teflon
+  G4OpticalSurface* teflon_optSurf =
+    new G4OpticalSurface("TEFLON_OPSURF", unified, ground, dielectric_metal);
+  teflon_optSurf->SetMaterialPropertiesTable(petopticalprops::PTFE());
+  new G4LogicalSkinSurface("TEFLON_OPSURF", teflon_block_logic, teflon_optSurf);
+
+  G4OpticalSurface* teflon_filt_optSurf =
+    new G4OpticalSurface("TEFLON_FILTER_OPSURF", unified, ground, dielectric_metal);
+  teflon_filt_optSurf->SetMaterialPropertiesTable(petopticalprops::PTFE());
+  new G4LogicalSkinSurface("TEFLON_FILTER_OPSURF", teflon_block_hama_filt_logic, teflon_filt_optSurf);
+
+  //Build VUV filter
+
+  NeutralFilterVUV filter_VUV = NeutralFilterVUV();
+  filter_VUV.Construct();
+  G4LogicalVolume* filter_VUV_logic = filter_VUV.GetLogicalVolume();
+  G4double filter_depth = filter_VUV.GetFilterDepth();
+  G4double dist_teflon_filter = 0.5 * mm;
+  G4double filter_z_pos = ih_z_size/2. + teflon_block_filter_thick - teflon_recess_depth + filter_depth/2. + dist_teflon_filter;
+
+  new G4PVPlacement(0, G4ThreeVector(0., 0., filter_z_pos), filter_VUV_logic,
+                    "FILTER_VUV", active_logic_, false, 0, false);
+
+  if (visibility_) {
+    G4VisAttributes block_col = nexus::LightBlue();
+    teflon_block_logic->SetVisAttributes(block_col);
+    teflon_block_hama_filt_logic->SetVisAttributes(block_col);
+    G4VisAttributes filt_col = nexus::LightGrey();
+    filter_VUV_logic->SetVisAttributes(filt_col);
+  }
+
+
+}
+
+
+void PETitFilter::BuildSensors()
+{
+  TileHamamatsuVUV tile = TileHamamatsuVUV();
+  tile.SetBoxConf(hama);
+  tile.SetTileVisibility(tile_vis_);
+  tile.SetTileReflectivity(tile_refl_);
+  tile.SetSiPMCells(sipm_cells_);
+  tile.Construct();
+
+  G4double tile_size_x = tile.GetDimensions().x();
+  G4double tile_size_y = tile.GetDimensions().y();
+  G4double tile_thickn = tile.GetDimensions().z();
+  G4double full_row_size = n_tile_columns_ * tile_size_x;
+  G4double full_col_size = n_tile_rows_ * tile_size_y;
+
+  G4LogicalVolume* tile_logic = tile.GetLogicalVolume();
+  G4String vol_name;
+  G4int copy_no = 0;
+  G4double z_pos =
+    -box_->GetBoxSize()/2. + box_->GetBoxThickness() + dist_dice_flange_
+    + tile_thickn/2.;
+
+  for (G4int j = 0; j < n_tile_rows_; j++) {
+    G4double y_pos = full_col_size/2. - tile_size_y/2. - j*tile_size_y;
+    for (G4int i = 0; i < n_tile_columns_; i++) {
+      G4double x_pos = -full_row_size/2. + tile_size_x/2. + i*tile_size_x;
+      vol_name = "TILE_" + std::to_string(copy_no);
+
+      new G4PVPlacement(0, G4ThreeVector(x_pos, y_pos, z_pos), tile_logic,
+                        vol_name, active_logic_, false, copy_no, false);
+      copy_no += 1;
+    }
+  }
+
+  G4RotationMatrix rot;
+  rot.rotateY(pi);
+
+  for (G4int j=0; j<n_tile_rows_; j++) {
+    G4double y_pos = full_col_size/2. - tile_size_y/2. - j*tile_size_y;
+    for (G4int i=0; i<n_tile_columns_; i++) {
+      G4double x_pos = full_row_size/2. - tile_size_x/2. - i*tile_size_x;
+      vol_name = "TILE_" + std::to_string(copy_no);
+
+      new G4PVPlacement(G4Transform3D(rot, G4ThreeVector(x_pos, y_pos, -z_pos)),
+                        tile_logic, vol_name, active_logic_,
+                        false, copy_no, false);
+      copy_no += 1;
+    }
+  }
+
+}
+
+G4ThreeVector PETitFilter::GenerateVertex(const G4String &region) const
+{
+  G4ThreeVector vertex(0., 0., 0.);
+
+  if (region == "CENTER") {
+    return vertex;
+  } else if (region == "AD_HOC") {
+    vertex = specific_vertex_;
+  } else if (region == "SOURCE") {
+    vertex = box_->GenerateVertex("SOURCE");
+  } else {
+    G4Exception("[PETit]", "GenerateVertex()", FatalException,
+                "Unknown vertex generation region!");
+  }
+  return vertex;
+}

--- a/source/geometries/PETitFilter.h
+++ b/source/geometries/PETitFilter.h
@@ -1,0 +1,60 @@
+// ----------------------------------------------------------------------------
+// petalosim | PETitFilter.h
+//
+// This class implements the geometry of a box of LXe with Hamamatsu tiles with
+// the VUV filter.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef PETITFILTER_H
+#define PETITFILTER_H
+
+#include "nexus/GeometryBase.h"
+
+class G4GenericMessenger;
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+
+class PETitBox;
+
+using namespace nexus;
+
+class PETitFilter : public GeometryBase
+{
+
+public:
+  // Constructor
+  PETitFilter();
+  //Destructor
+  ~PETitFilter();
+
+  /// Generate a vertex within a given region of the geometry
+  G4ThreeVector GenerateVertex(const G4String &region) const;
+
+private:
+  void Construct();
+  void BuildBox();
+  void BuildSensors();
+
+  G4LogicalVolume* lab_logic_;
+  G4LogicalVolume* active_logic_;
+
+  G4bool visibility_;
+  G4bool box_vis_, tile_vis_;
+  G4double tile_refl_;
+  G4double dist_dice_flange_;
+  G4double n_tile_rows_, n_tile_columns_;
+
+  G4ThreeVector specific_vertex_;
+
+  G4bool sipm_cells_;
+  G4double max_step_size_, pressure_;
+
+  /// Messenger for the definition of control commands
+  G4GenericMessenger* msg_;
+
+  PETitBox* box_;
+};
+
+#endif

--- a/source/geometries/TeflonBlockHamamatsuFilter.cc
+++ b/source/geometries/TeflonBlockHamamatsuFilter.cc
@@ -1,0 +1,147 @@
+// ----------------------------------------------------------------------------
+// petalosim | TeflonBlockHamamatsuFilter.h
+//
+// Teflon block used with the Hamamatsu VUV tiles when using the VUV filter.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#include "TeflonBlockHamamatsuFilter.h"
+
+#include "nexus/IonizationSD.h"
+#include "nexus/Visibilities.h"
+#include "nexus/FactoryBase.h"
+
+#include <G4Box.hh>
+#include <G4LogicalVolume.hh>
+#include <G4PVPlacement.hh>
+#include <G4NistManager.hh>
+#include <G4Material.hh>
+#include <G4UserLimits.hh>
+#include <G4SubtractionSolid.hh>
+#include <G4VisAttributes.hh>
+#include <G4GenericMessenger.hh>
+
+using namespace nexus;
+
+REGISTER_CLASS(TeflonBlockHamamatsuFilter, GeometryBase)
+
+TeflonBlockHamamatsuFilter::TeflonBlockHamamatsuFilter(): GeometryBase(),
+                                              visibility_(0),
+                                              teflon_block_thick_(35.75 * mm),
+                                              max_step_size_(1.*mm),
+                                              teflon_recess_depth_(3 * mm)
+{
+
+  // Messenger
+  msg_ = new G4GenericMessenger(this, "/Geometry/TeflonBlockHamamatsuFilter/",
+                                "Control commands of geometry PETitFilter.");
+  msg_->DeclareProperty("visibility", visibility_, "Visibility");
+
+
+}
+
+TeflonBlockHamamatsuFilter::~TeflonBlockHamamatsuFilter()
+{
+}
+
+
+void TeflonBlockHamamatsuFilter::Construct()
+{
+  G4double teflon_block_xy = 67 * mm;
+
+  // Recess dimensions
+  G4double recess_x = 50 * mm;
+  G4double recess_y = 58 * mm;
+
+  //Absolute positions of recess from center
+  G4double recess_y_center = (teflon_block_xy - recess_y)/2. * mm;
+  G4double recess_z_center = -teflon_block_thick_ + 1. * mm;
+  G4ThreeVector recess_pos(0, recess_y_center, recess_z_center);
+
+  G4double teflon_offset_x = 3.64 * mm;
+  G4double teflon_offset_y = 3.7  * mm;
+
+  G4double teflon_central_offset_x = 3.23 * mm;
+  G4double teflon_central_offset_y = 3.11 * mm;
+
+  G4double teflon_holes_xy    = 5.75 * mm;
+  G4double teflon_holes_depth = 5    * mm;
+
+  G4double dist_between_holes_xy = 1.75 * mm;
+
+  // Create de teflon block
+  G4Box* teflon_block_solid =
+    new G4Box("TEFLON_BLOCK", teflon_block_xy/2., teflon_block_xy/2., teflon_block_thick_/2.);
+
+  G4Material *teflon = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+  teflon->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
+  // Create de substraction block
+  G4Box* teflon_recess_solid =
+    new G4Box("TEFLON_RECESS", recess_x/2., recess_y/2., (teflon_recess_depth_ + 1.)/2.);
+
+  G4SubtractionSolid* subtracted_block_solid =
+    new G4SubtractionSolid("TEFLON_BLOCK_RECESS", teflon_block_solid, teflon_recess_solid, 0, recess_pos);
+
+  G4LogicalVolume* teflon_block_logic =
+    new G4LogicalVolume(subtracted_block_solid, teflon, "TEFLON_BLOCK");
+    this->SetLogicalVolume(teflon_block_logic);
+
+  // Holes in the block which are filled with LXe and defined as LXe vols
+  G4double dist_four_holes = 4* teflon_holes_xy + 3*dist_between_holes_xy;
+
+  G4Box* teflon_hole_solid =
+    new G4Box("ACTIVE", teflon_holes_xy/2., teflon_holes_xy/2., teflon_holes_depth/2.);
+
+  G4LogicalVolume* teflon_hole_logic =
+    new G4LogicalVolume(teflon_hole_solid, mat_, "ACTIVE");
+
+  // Set the ACTIVE volume as an ionization sensitive det
+  teflon_hole_logic->SetSensitiveDetector(ionisd_);
+  teflon_hole_logic->SetUserLimits(new G4UserLimits(max_step_size_));
+
+  G4double holes_pos_z = -teflon_block_thick_/2. + teflon_holes_depth/2. + teflon_recess_depth_;
+
+  G4int copy_no = 0;
+
+  for (G4int j = 0; j < 2; j++){ // Loop over the tiles in row
+    G4double set_holes_y = teflon_block_xy/2. - teflon_offset_y - dist_four_holes/2.
+      - j*(teflon_central_offset_y + dist_four_holes);
+
+    for (G4int i = 0; i < 2; i++){ // Loop over the tiles in column
+      G4double set_holes_x = -teflon_block_xy/2. + teflon_offset_x + dist_four_holes/2.
+        + i*(teflon_central_offset_x + dist_four_holes);
+
+      for (G4int l = 0; l < 4; l++){ // Loop over the sensors in row
+        G4double holes_pos_y = set_holes_y + 3*(teflon_holes_xy/2. + dist_between_holes_xy/2.)
+          - l*(teflon_holes_xy + dist_between_holes_xy);
+
+        for (G4int k = 0; k < 4; k++){ // Loop over the sensors in column
+          G4double holes_pos_x = set_holes_x - 3*(teflon_holes_xy/2. + dist_between_holes_xy/2.)
+            + k*(teflon_holes_xy + dist_between_holes_xy);
+
+          //Global matrix index
+          G4int global_row = j * 4 + l;
+          G4int global_col = i * 4 + k;
+
+          G4bool is_edge = (global_row == 0 || global_row == 7 || global_col == 0 || global_col == 7);
+
+          G4double hole_z = is_edge ?
+                            (-teflon_block_thick_/2. + teflon_holes_depth/2.) :
+                            (holes_pos_z);
+
+          new G4PVPlacement(0, G4ThreeVector(holes_pos_x, holes_pos_y, hole_z), teflon_hole_logic,
+                            "ACTIVE", teflon_block_logic, false, copy_no, false);
+          copy_no += 1;
+        }
+      }
+    }
+  }
+
+  if (visibility_) {
+    G4VisAttributes teflon_col = nexus::LightBlue();
+    teflon_block_logic->SetVisAttributes(teflon_col);
+  }
+
+}

--- a/source/geometries/TeflonBlockHamamatsuFilter.h
+++ b/source/geometries/TeflonBlockHamamatsuFilter.h
@@ -1,0 +1,63 @@
+// ----------------------------------------------------------------------------
+// petalosim | TeflonBlockHamamatsuFilter.h
+//
+// Teflon block used with the Hamamatsu VUV tiles when using the VUV filter.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef TEFLON_HAMA_FILT_H
+#define TEFLON_HAMA_FILT_H
+
+#include "nexus/GeometryBase.h"
+
+class G4GenericMessenger;
+class G4Material;
+
+namespace nexus
+{
+class IonizationSD;
+}
+
+using namespace nexus;
+
+class TeflonBlockHamamatsuFilter: public GeometryBase
+{
+public:
+  // Constructor
+  TeflonBlockHamamatsuFilter();
+  //Destructor
+  ~TeflonBlockHamamatsuFilter();
+
+  void Construct();
+
+  void SetHoleMaterial(G4Material* mat);
+  void SetIoniSD(IonizationSD* ionisd);
+  void SetMaxStepSize(G4double step_size);
+
+  G4double GetTeflonThickness() const;
+  G4double GetTeflonRecessDepth() const;
+
+ private:
+
+  G4Material* mat_;
+  IonizationSD* ionisd_;
+  G4double teflon_block_thick_;
+  G4double max_step_size_;
+  G4double teflon_recess_depth_;
+  G4bool visibility_;
+  
+  /// Messenger for the definition of control commands
+  G4GenericMessenger* msg_;
+
+
+
+};
+
+inline void TeflonBlockHamamatsuFilter::SetHoleMaterial(G4Material* mat) {mat_ = mat;}
+inline void TeflonBlockHamamatsuFilter::SetIoniSD(IonizationSD* ionisd) {ionisd_ = ionisd;}
+inline void TeflonBlockHamamatsuFilter::SetMaxStepSize(G4double step_size) {max_step_size_ = step_size;}
+inline G4double TeflonBlockHamamatsuFilter::GetTeflonThickness() const {return teflon_block_thick_;}
+inline G4double TeflonBlockHamamatsuFilter::GetTeflonRecessDepth() const {return teflon_recess_depth_;}
+
+#endif


### PR DESCRIPTION
This PR includes the new geometry of the Teflon block used with the VUV filter, along with the macro files needed to run it independently for testing purposes. It also includes the updated PETit geometry, incorporating the new block and VUV filter, with the corresponding macros to run the simulations.