### PR TITLE
Fix issues to avoid overlapping volumes in the filter

### DIFF
--- a/source/geometries/NeutralFilterVUV.cc
+++ b/source/geometries/NeutralFilterVUV.cc
@@ -35,7 +35,7 @@ void NeutralFilterVUV::Construct()
   G4double filter_xy = 50 * mm;
 
   G4Box* filter_solid =
-      new G4Box("FILTER", filter_xy/2., filter_xy/2., filter_depth_/2);
+      new G4Box("FILTER", filter_xy/2., filter_xy/2., filter_depth_/2.);
 
   G4Material* fused_silica = materials::FusedSilica();
 
@@ -71,7 +71,7 @@ void NeutralFilterVUV::Construct()
                                 7.59384 * eV, 7.69538 * eV, 7.79692 * eV, 7.89846 * eV,
                                 8.      * eV};
 
-  G4double absorption_length_lin_25[entries] = {26.96192 * mm, 26.84297 * mm, 26.72887 * mm, 26.57202 * mm,
+  G4double absorption_length_lin[entries] = {26.96192 * mm, 26.84297 * mm, 26.72887 * mm, 26.57202 * mm,
                                                 26.15263 * mm, 25.73203 * mm, 25.36811 * mm, 25.07453 * mm,
                                                 25.02241 * mm, 24.76914 * mm, 24.53542 * mm, 24.48358 * mm,
                                                 24.36648 * mm, 24.26932 * mm, 24.14035 * mm, 23.95741 * mm,
@@ -119,6 +119,30 @@ void NeutralFilterVUV::Construct()
                                                 9.83539 * mm,  9.83543 * mm,  9.83552 * mm,  9.83571 * mm,
                                                 9.83601 * mm};
 
+   G4double absorption_length_100[entries] = {26.96192 * mm, 26.84297 * mm, 26.72887 * mm, 26.57202 * mm,
+                                              26.15263 * mm, 25.73203 * mm, 25.36811 * mm, 25.07453 * mm,
+                                              25.02241 * mm, 24.76914 * mm, 24.53542 * mm, 24.48358 * mm,
+                                              24.36648 * mm, 24.26932 * mm, 24.14035 * mm, 23.95741 * mm,
+                                              23.81487 * mm, 23.70949 * mm, 23.47045 * mm, 23.36710 * mm,
+                                              23.27099 * mm, 23.06620 * mm, 22.90031 * mm, 22.78820 * mm,
+                                              22.69084 * mm, 22.59654 * mm, 22.42481 * mm, 22.30474 * mm,
+                                              22.24708 * mm, 22.02781 * mm, 21.93943 * mm, 21.82708 * mm,
+                                              21.64325 * mm, 21.49492 * mm, 21.37272 * mm, 21.27086 * mm,
+                                              21.14495 * mm, 21.00218 * mm, 20.94942 * mm, 20.73323 * mm,
+                                              20.66441 * mm, 20.66505 * mm, 20.43412 * mm, 20.29423 * mm,
+                                              20.23625 * mm, 20.02656 * mm, 19.90508 * mm, 19.86716 * mm,
+                                              19.63604 * mm, 19.38718 * mm, 19.25203 * mm, 18.95896 * mm,
+                                              18.71424 * mm, 18.45051 * mm, 18.06848 * mm, 17.63308 * mm,
+                                              17.08074 * mm, 16.57175 * mm, 15.91383 * mm, 15.11595 * mm,
+                                              14.31973 * mm, 13.64823 * mm, 13.06188 * mm, 12.52931 * mm,
+                                              12.06524 * mm, 11.69885 * mm, 11.36311 * mm, 11.05203 * mm,
+                                              10.72835 * mm, 10.25560 * mm,  9.6547  * mm,  1e6     * m,
+                                               1e6     * m,   1e6     * m,   1e6     * m,   1e6     * m,
+                                               1e6     * m,   1e6     * m,   1e6     * m,   1e6     * m,
+                                               1e6     * m,   1e6     * m,   1e6     * m,   1e6     * m,
+                                               1e6     * m,   1e6     * m,   1e6     * m,   1e6     * m,
+                                               1e6     * m};
+
   G4double refraction_index_m110[entries] = {1.45020, 1.45035, 1.45049, 1.45064, 1.45079,
                                              1.45095, 1.45110, 1.45126, 1.45143, 1.45159,
                                              1.45177, 1.45194, 1.45212, 1.45230, 1.45249,
@@ -160,7 +184,7 @@ void NeutralFilterVUV::Construct()
   // Add filter properties due to the fused silica material
   G4MaterialPropertiesTable* silica_mpt = new G4MaterialPropertiesTable();
   silica_mpt->AddProperty("RINDEX", energies, refraction_index_25, entries);
-  silica_mpt->AddProperty("ABSLENGTH", energies, absorption_length_lin_25, entries);
+  silica_mpt->AddProperty("ABSLENGTH", energies, absorption_length_lin, entries);
 
   fused_silica->SetMaterialPropertiesTable(silica_mpt);
 

--- a/source/geometries/PETitFilter.cc
+++ b/source/geometries/PETitFilter.cc
@@ -140,7 +140,6 @@ void PETitFilter::BuildBox()
   G4LogicalVolume* teflon_block_hama_filt_logic = teflon_block_hama_filt.GetLogicalVolume();
 
   G4double teflon_block_filter_thick = teflon_block_hama_filt.GetTeflonThickness();
-  G4double teflon_recess_depth = teflon_block_hama_filt.GetTeflonRecessDepth();
   G4double block_z_pos_filt = ih_z_size/2. + teflon_block_filter_thick/2.;
 
   G4RotationMatrix rot_teflon;
@@ -166,12 +165,12 @@ void PETitFilter::BuildBox()
   NeutralFilterVUV filter_VUV = NeutralFilterVUV();
   filter_VUV.Construct();
   G4LogicalVolume* filter_VUV_logic = filter_VUV.GetLogicalVolume();
-  G4double filter_depth = filter_VUV.GetFilterDepth();
-  G4double dist_teflon_filter = 0.5 * mm;
-  G4double filter_z_pos = ih_z_size/2. + teflon_block_filter_thick - teflon_recess_depth + filter_depth/2. + dist_teflon_filter;
+  //Teflon recess logical volume to insert the filter without overlaps
+  G4LogicalVolume* recess_logic = teflon_block_hama_filt.GetRecessLogic();
 
-  new G4PVPlacement(0, G4ThreeVector(0., 0., filter_z_pos), filter_VUV_logic,
-                    "FILTER_VUV", active_logic_, false, 0, false);
+  new G4PVPlacement(0, G4ThreeVector(0., 0., 0.), filter_VUV_logic,
+                      "FILTER_VUV", recess_logic , false, 0, false);
+
 
   if (visibility_) {
     G4VisAttributes block_col = nexus::LightBlue();

--- a/source/geometries/TeflonBlockHamamatsuFilter.cc
+++ b/source/geometries/TeflonBlockHamamatsuFilter.cc
@@ -30,7 +30,7 @@ TeflonBlockHamamatsuFilter::TeflonBlockHamamatsuFilter(): GeometryBase(),
                                               visibility_(0),
                                               teflon_block_thick_(35.75 * mm),
                                               max_step_size_(1.*mm),
-                                              teflon_recess_depth_(3 * mm)
+                                              teflon_recess_depth_(3. * mm)
 {
 
   // Messenger
@@ -48,16 +48,16 @@ TeflonBlockHamamatsuFilter::~TeflonBlockHamamatsuFilter()
 
 void TeflonBlockHamamatsuFilter::Construct()
 {
-  G4double teflon_block_xy = 67 * mm;
+  G4double teflon_block_xy = 67. * mm;
 
   // Recess dimensions
-  G4double recess_x = 50 * mm;
-  G4double recess_y = 58 * mm;
+  G4double recess_x = 50. * mm;
+  G4double recess_y = 58. * mm;
 
   //Absolute positions of recess from center
-  G4double recess_y_center = (teflon_block_xy - recess_y)/2. * mm;
-  G4double recess_z_center = -teflon_block_thick_ + 1. * mm;
-  G4ThreeVector recess_pos(0, recess_y_center, recess_z_center);
+  G4double recess_y_center = (teflon_block_xy - recess_y - 0.01 * mm)/2.;
+  G4double recess_z_center = -teflon_block_thick_/2. + (teflon_recess_depth_ + 0.4 * mm)/2.;
+  G4ThreeVector recess_pos(0, recess_y_center, + recess_z_center + 0.01*mm);
 
   G4double teflon_offset_x = 3.64 * mm;
   G4double teflon_offset_y = 3.7  * mm;
@@ -66,9 +66,10 @@ void TeflonBlockHamamatsuFilter::Construct()
   G4double teflon_central_offset_y = 3.11 * mm;
 
   G4double teflon_holes_xy    = 5.75 * mm;
-  G4double teflon_holes_depth = 5    * mm;
+  G4double teflon_holes_depth = 5.    * mm;
 
   G4double dist_between_holes_xy = 1.75 * mm;
+
 
   // Create de teflon block
   G4Box* teflon_block_solid =
@@ -79,7 +80,7 @@ void TeflonBlockHamamatsuFilter::Construct()
 
   // Create de substraction block
   G4Box* teflon_recess_solid =
-    new G4Box("TEFLON_RECESS", recess_x/2., recess_y/2., (teflon_recess_depth_ + 1.)/2.);
+    new G4Box("TEFLON_RECESS", recess_x/2., recess_y/2., (teflon_recess_depth_ + 0.4 * mm)/2.);
 
   G4SubtractionSolid* subtracted_block_solid =
     new G4SubtractionSolid("TEFLON_BLOCK_RECESS", teflon_block_solid, teflon_recess_solid, 0, recess_pos);
@@ -87,6 +88,13 @@ void TeflonBlockHamamatsuFilter::Construct()
   G4LogicalVolume* teflon_block_logic =
     new G4LogicalVolume(subtracted_block_solid, teflon, "TEFLON_BLOCK");
     this->SetLogicalVolume(teflon_block_logic);
+
+  // Create the logic volume for the recess teflon to avoid overlaps
+  G4Material* LXe = G4NistManager::Instance()->FindOrBuildMaterial("G4_lXe");
+  G4LogicalVolume* teflon_recess_logic = new G4LogicalVolume(teflon_recess_solid, LXe, "TEFLON_RECESS_LOGIC");
+  teflon_recess_logic_ = teflon_recess_logic; //To be able to call it
+  new G4PVPlacement(0, recess_pos, teflon_recess_logic, "TEFLON_RECESS_PV",
+                    teflon_block_logic, false, 0, false);
 
   // Holes in the block which are filled with LXe and defined as LXe vols
   G4double dist_four_holes = 4* teflon_holes_xy + 3*dist_between_holes_xy;

--- a/source/geometries/TeflonBlockHamamatsuFilter.h
+++ b/source/geometries/TeflonBlockHamamatsuFilter.h
@@ -37,6 +37,7 @@ public:
 
   G4double GetTeflonThickness() const;
   G4double GetTeflonRecessDepth() const;
+  G4LogicalVolume* GetRecessLogic() const;
 
  private:
 
@@ -49,7 +50,9 @@ public:
   
   /// Messenger for the definition of control commands
   G4GenericMessenger* msg_;
-
+  
+  // Logical volume of the recess for placing the filter
+  G4LogicalVolume* teflon_recess_logic_;
 
 
 };
@@ -59,5 +62,6 @@ inline void TeflonBlockHamamatsuFilter::SetIoniSD(IonizationSD* ionisd) {ionisd_
 inline void TeflonBlockHamamatsuFilter::SetMaxStepSize(G4double step_size) {max_step_size_ = step_size;}
 inline G4double TeflonBlockHamamatsuFilter::GetTeflonThickness() const {return teflon_block_thick_;}
 inline G4double TeflonBlockHamamatsuFilter::GetTeflonRecessDepth() const {return teflon_recess_depth_;}
+inline G4LogicalVolume* TeflonBlockHamamatsuFilter::GetRecessLogic() const {return teflon_recess_logic_;}
 
 #endif


### PR DESCRIPTION
This PR includes changes in the files to prevent the filter volume from overlapping with the teflon block volume. The teflon recess was not properly defined, which caused the overlap. It is now filled with LXe, eliminating any overlaps between the volumes.
